### PR TITLE
docs: refresh README for v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # InstantCMS MCP Server
 
+[![CI](https://github.com/instantcms-dev/instantcms-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/instantcms-dev/instantcms-mcp/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/instantcms-dev/instantcms-mcp)](https://github.com/instantcms-dev/instantcms-mcp/releases/latest)
+[![Node.js](https://img.shields.io/badge/Node.js-18%20%7C%2020%20%7C%2022%20%7C%2024-339933)](https://nodejs.org/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 MCP-сервер и набор переносимых AI-workflows для разработки дополнений, виджетов, шаблонов и layout-схем InstantCMS 2.
 
-Сервер предоставляет структурированную базу хуков и API, безопасные генераторы, валидатор пакетов и ресурсы контекста. Проект протестирован с InstantCMS 2.18.1; сведения, зависящие от версии, следует сверять с `knowledge/metadata.yaml`.
+Сервер предоставляет структурированную базу API InstantCMS, безопасные генераторы, валидатор пакетов, диагностические инструменты и MCP resources. Runtime-данные синхронизированы с официальным репозиторием [`instantsoft/icms2`](https://github.com/instantsoft/icms2), последняя проверенная стабильная версия — **InstantCMS 2.18.2**.
+
+Текущий релиз: [`v1.2.0`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.0). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
 
 ## Возможности
 
@@ -14,6 +21,10 @@ MCP-сервер и набор переносимых AI-workflows для раз
 - диагностические коды для автоматического исправления;
 - экранирование пользовательских данных для XML, INI, PHP и YAML;
 - AI-инструкции и skills без дублирования базы знаний.
+- 81 MCP-инструмент и четыре встроенных MCP resource;
+- воспроизводимая генерация runtime-справочников из зафиксированного commit InstantCMS;
+- автоматическая еженедельная проверка обновлений и Pull Request с изменившимися данными;
+- CI на Node.js 18, 20, 22 и 24 с отдельной проверкой официальных исходников InstantCMS.
 
 ## Требования и установка
 
@@ -21,9 +32,13 @@ MCP-сервер и набор переносимых AI-workflows для раз
 - npm.
 
 ```bash
+git clone https://github.com/instantcms-dev/instantcms-mcp.git
+cd instantcms-mcp
 npm ci
 npm run build
 ```
+
+Либо скачайте готовый ZIP из [последнего GitHub Release](https://github.com/instantcms-dev/instantcms-mcp/releases/latest).
 
 Подключение к MCP-клиенту:
 
@@ -46,34 +61,50 @@ npm run inspector
 npm run check
 ```
 
+`npm run check` выполняет проверку provenance/generated metadata, TypeScript, 245 unit-тестов и конфигураций AI-клиентов. Интеграционный MCP smoke-test запускается отдельно командой `npm run test:integration`.
+
 ## Основные MCP-инструменты
 
 Сервер регистрирует 81 инструмент. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, templates и анализ исходников.
 
-| Инструмент | Назначение |
-|---|---|
-| `get_addon_structure` | Структура выбранного типа дополнения |
-| `scaffold_addon` | Генерация полного installation package tree |
-| `list_hooks` | Список хуков с фильтрами |
-| `get_hook_details` | Детали и пример конкретного хука |
-| `search_hooks` | Поиск по имени, описанию и параметрам |
-| `get_component_api` | API класса или компонента |
-| `list_components` | Список документированных компонентов |
-| `validate_addon` | Валидация структуры и кода дополнения |
-| `get_field_types` | Справочник полей форм |
-| `get_code_example` | Примеры типовых операций |
-| `scaffold_template` | Генерация базовой темы |
-| `get_template_structure` | Структура и правила шаблонов |
-| `scaffold_layout_scheme` | Генерация импортируемой YAML-схемы |
-| `list_layout_presets` | Доступные layout-пресеты |
-| `get_server_capabilities` | Версии и объём базы знаний |
-| `find_tool` / `get_workflow` | Подбор инструмента и последовательности вызовов |
-| `diagnose_request` | Определение типа задачи |
-| `compare_instantcms_versions` | Сравнение version profiles |
-| `validate_generated_artifacts` | Разбор XML, INI, YAML и проверка PHP-формы |
-| `build_addon_archive` / `inspect_addon_archive` | Создание и проверка ZIP в памяти |
+| Инструмент                                      | Назначение                                      |
+| ----------------------------------------------- | ----------------------------------------------- |
+| `get_addon_structure`                           | Структура выбранного типа дополнения            |
+| `scaffold_addon`                                | Генерация полного installation package tree     |
+| `list_hooks`                                    | Список хуков с фильтрами                        |
+| `get_hook_details`                              | Детали и пример конкретного хука                |
+| `search_hooks`                                  | Поиск по имени, описанию и параметрам           |
+| `get_component_api`                             | API класса или компонента                       |
+| `list_components`                               | Список документированных компонентов            |
+| `validate_addon`                                | Валидация структуры и кода дополнения           |
+| `get_field_types`                               | Справочник полей форм                           |
+| `get_code_example`                              | Примеры типовых операций                        |
+| `scaffold_template`                             | Генерация базовой темы                          |
+| `get_template_structure`                        | Структура и правила шаблонов                    |
+| `scaffold_layout_scheme`                        | Генерация импортируемой YAML-схемы              |
+| `list_layout_presets`                           | Доступные layout-пресеты                        |
+| `get_server_capabilities`                       | Версии и объём базы знаний                      |
+| `find_tool` / `get_workflow`                    | Подбор инструмента и последовательности вызовов |
+| `diagnose_request`                              | Определение типа задачи                         |
+| `compare_instantcms_versions`                   | Сравнение version profiles                      |
+| `validate_generated_artifacts`                  | Разбор XML, INI, YAML и проверка PHP-формы      |
+| `build_addon_archive` / `inspect_addon_archive` | Создание и проверка ZIP в памяти                |
 
 Сервер также публикует MCP resources со всеми хуками, компонентами, типами дополнений и quickstart.
+
+### Группы инструментов
+
+| Registry          | Количество | Что входит                                                                       |
+| ----------------- | ---------: | -------------------------------------------------------------------------------- |
+| `meta-tools`      |         10 | capabilities, подбор workflow, диагностика, версии и артефакты                   |
+| `generator-tools` |         13 | addon, CRUD, формы, grid, REST API, тесты, email, cron и overrides               |
+| `knowledge-tools` |         20 | хуки, компоненты, поля, шаблоны, layout, БД и контроллеры                        |
+| `database-tools`  |          6 | безопасный доступ к MariaDB и исследование таблиц                                |
+| `source-tools`    |         12 | widgets, traits, fields, routes, миграции и анализ требований                    |
+| `language-tools`  |          3 | языковые ключи, language files и migration scaffold                              |
+| `extension-tools` |         17 | WYSIWYG, permissions, filters, SEO, import/export, cache, webhooks, OAuth и темы |
+
+Полные имена, входные Zod-схемы и описания доступны клиенту через стандартный MCP `tools/list`. Для начала неизвестной задачи используйте `diagnose_request`, `find_tool` или `get_workflow`.
 
 ## Структура проекта
 
@@ -86,9 +117,11 @@ src/
 ├── server.ts                # composition root MCP-сервера
 └── index.ts                 # stdio entrypoint
 knowledge/                   # provenance и будущий источник данных
+├── catalog.yaml             # проверяемый каталог runtime-источников
+└── upstream.json            # зафиксированные ref, commit и дата InstantCMS
 skills/                      # переносимые AI-workflows
 evals/                       # кросс-клиентские сценарии
-test/                        # автоматические тесты
+.github/workflows/           # CI, release и еженедельная синхронизация
 AGENTS.md                    # общие инструкции coding agents
 CLAUDE.md                    # тонкий адаптер Claude
 ```
@@ -103,6 +136,38 @@ GitHub `main` является единственным источником и�
 
 Исходники кэшируются в `.cache/icms2`. Сетевой доступ нужен только во время обновления; MCP и npm-пакет используют проверенный snapshot автономно. `npm run knowledge:check` проверяет provenance-манифест и generated metadata.
 
+### Как работает синхронизация
+
+```text
+instantsoft/icms2 (tag или branch)
+        ↓ shallow fetch
+.cache/icms2
+        ↓ deterministic parsers
+src/data/*.ts + knowledge/upstream.json
+        ↓ typecheck + tests + review
+Git commit / release snapshot
+```
+
+`latest` выбирает максимальный стабильный semver-тег из `git ls-remote`. Сейчас он разрешается в тег `2.18.2` и commit `4a13609c480cccfcbd27dbab424d6bf00ad67375`. Время генерации берётся из upstream commit, поэтому повторный запуск для одного SHA не создаёт шумовой diff.
+
+Основные команды:
+
+```bash
+# Проверить, появился ли новый stable commit (код 2 означает доступное обновление)
+npm run knowledge:source:status -- --ref latest
+
+# Обновить snapshot с последнего стабильного тега
+npm run knowledge:update -- --ref latest
+
+# Проверить совместимость с веткой разработки InstantCMS
+npm run knowledge:update -- --ref master
+
+# Проверить каталог без доступа к сети
+npm run knowledge:check
+```
+
+Workflow `Sync InstantCMS knowledge` запускается каждый понедельник и создаёт PR только при фактическом изменении snapshot. Workflow `CI` дополнительно заново генерирует данные из последнего stable-тега на каждом PR и push.
+
 Не синхронизируйте проект копированием поверх clone с удалением отсутствующих файлов. База GitHub содержит расширенные инструменты, которых может не быть в старых локальных копиях.
 
 ## AI-интеграция
@@ -115,6 +180,14 @@ Skills разделены по workflow:
 - `skills/instantcms-audit` — аудит структуры, синтаксиса и безопасности.
 
 Большие справочники не копируются в skills. Агент получает факты через MCP tools/resources и `knowledge/`, а skill определяет порядок работы и критерии готовности.
+
+### Подключение AI-клиентов
+
+- **Codex и совместимые coding agents:** читают корневой `AGENTS.md` и skills из `skills/`.
+- **Claude Code:** начинает с `CLAUDE.md`, который направляет к каноническому `AGENTS.md`.
+- **OpenCode и другие MCP-клиенты:** используют конфигурацию `mcpServers` выше и те же MCP tools/resources; проектные правила остаются в `AGENTS.md`.
+
+Так правила разработки не расходятся между клиентами, а предметные данные обновляются один раз через knowledge pipeline.
 
 ## Структура генерируемого пакета
 
@@ -170,6 +243,12 @@ npm run build
 ```
 
 Тесты покрывают безопасную сериализацию, строгую проверку имён и версий, YAML scalars, неоднозначный поиск и round-trip `scaffoldAddon → validateAddon`.
+
+## Релизы и защита main
+
+Изменения в `main` принимаются через Pull Request. GitHub требует успешные `Build`, Node.js 18/20/22/24 и `InstantCMS upstream compatibility`, один approving review, разрешение обсуждений и линейную историю. Force-push и удаление `main` запрещены классической branch protection и repository ruleset `Protect main`.
+
+Push тега `v*` запускает `.github/workflows/release.yml`: тесты, сборку, lint, создание ZIP и GitHub Release. Публикация в npm является отдельным шагом и требует рабочего repository secret `NPM_TOKEN` с правом создавать/обновлять пакет `instantcms-mcp`.
 
 ## Лицензия
 


### PR DESCRIPTION
## Summary

- document all 81 MCP tools by registry group
- explain official InstantCMS stable/master knowledge synchronization
- document CI, AI adapters, releases, and main protection
- update tested InstantCMS version and release links

## Verification

- npm run check
- Prettier README check
- GitHub ruleset Protect main is active