### PR TITLE
Add agent project workflows

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,6 +6,7 @@
 
 - `src/server.ts` is the composition root: it creates the MCP server and invokes domain registrars.
 - `src/registry/` owns transport-facing Zod schemas and tool/resource registration, split into generators, knowledge, database, source analysis, language, extensions, metadata, and resources.
+- `src/registry/project-tools.ts` exposes read-only project analysis, reviewable repair planning, safe file-map transformations, and version upgrade planning.
 - `src/utils/mcp-result.ts` задаёт единый `content + structuredContent + isError` контракт.
 - `src/utils/pagination.ts` реализует cursor pagination для больших справочников.
 - `src/tools/` contains deterministic domain operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Generate hook inventory and core component APIs from the pinned official InstantCMS source while preserving curated descriptions and examples.
 - Expose source file provenance for discovered hooks and components.
+- Add project audit, explain, plan, safe repair, and version upgrade MCP workflows.
+- Add focused migration, widget, theme, API, upgrade, debug, and security skills.
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 - диагностические коды для автоматического исправления;
 - экранирование пользовательских данных для XML, INI, PHP и YAML;
 - AI-инструкции и skills без дублирования базы знаний.
-- 81 MCP-инструмент и четыре встроенных MCP resource;
+- 86 MCP-инструментов и четыре встроенных MCP resource;
 - воспроизводимая генерация runtime-справочников из зафиксированного commit InstantCMS;
 - автоматическая еженедельная проверка обновлений и Pull Request с изменившимися данными;
 - CI на Node.js 18, 20, 22 и 24 с отдельной проверкой официальных исходников InstantCMS.
@@ -65,7 +65,7 @@ npm run check
 
 ## Основные MCP-инструменты
 
-Сервер регистрирует 81 инструмент. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, templates и анализ исходников.
+Сервер регистрирует 86 инструментов. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, templates, аудит существующих проектов и планирование обновлений.
 
 | Инструмент                                      | Назначение                                      |
 | ----------------------------------------------- | ----------------------------------------------- |
@@ -89,6 +89,11 @@ npm run check
 | `compare_instantcms_versions`                   | Сравнение version profiles                      |
 | `validate_generated_artifacts`                  | Разбор XML, INI, YAML и проверка PHP-формы      |
 | `build_addon_archive` / `inspect_addon_archive` | Создание и проверка ZIP в памяти                |
+| `audit_instantcms_project`                      | Комплексный аудит существующего file map        |
+| `plan_project_changes`                          | План исправлений без изменения файлов           |
+| `repair_instantcms_project`                     | Только безопасные структурные исправления       |
+| `explain_instantcms_project`                    | Краткая карта существующего проекта             |
+| `plan_instantcms_upgrade`                       | План обновления между версиями InstantCMS       |
 
 Сервер также публикует MCP resources со всеми хуками, компонентами, типами дополнений и quickstart.
 
@@ -103,6 +108,7 @@ npm run check
 | `source-tools`    |         12 | widgets, traits, fields, routes, миграции и анализ требований                    |
 | `language-tools`  |          3 | языковые ключи, language files и migration scaffold                              |
 | `extension-tools` |         17 | WYSIWYG, permissions, filters, SEO, import/export, cache, webhooks, OAuth и темы |
+| `project-tools`   |          5 | аудит, объяснение проекта, план, безопасный repair и upgrade planner             |
 
 Полные имена, входные Zod-схемы и описания доступны клиенту через стандартный MCP `tools/list`. Для начала неизвестной задачи используйте `diagnose_request`, `find_tool` или `get_workflow`.
 
@@ -178,6 +184,15 @@ Skills разделены по workflow:
 
 - `skills/instantcms-addon` — проектирование и генерация дополнений;
 - `skills/instantcms-audit` — аудит структуры, синтаксиса и безопасности.
+- `skills/instantcms-migration` — миграции и изменения схемы БД;
+- `skills/instantcms-widget` — виджеты, options и caching;
+- `skills/instantcms-theme` — темы, overrides и layout schemes;
+- `skills/instantcms-api` — REST, external API, OAuth и webhooks;
+- `skills/instantcms-upgrade` — обновление между версиями InstantCMS;
+- `skills/instantcms-debug` — диагностика runtime и installation failures;
+- `skills/instantcms-security` — целевой security review.
+
+Для существующего проекта рекомендуемый агентный цикл: `explain_instantcms_project → audit_instantcms_project → plan_project_changes → review → repair_instantcms_project → audit_instantcms_project`. Инструмент repair возвращает новый file map и не записывает файлы самостоятельно.
 
 Большие справочники не копируются в skills. Агент получает факты через MCP tools/resources и `knowledge/`, а skill определяет порядок работы и критерии готовности.
 

--- a/scripts/check-ai-configs.mjs
+++ b/scripts/check-ai-configs.mjs
@@ -5,6 +5,13 @@ const required = [
   'CLAUDE.md',
   'skills/instantcms-addon/SKILL.md',
   'skills/instantcms-audit/SKILL.md',
+  'skills/instantcms-migration/SKILL.md',
+  'skills/instantcms-widget/SKILL.md',
+  'skills/instantcms-theme/SKILL.md',
+  'skills/instantcms-api/SKILL.md',
+  'skills/instantcms-upgrade/SKILL.md',
+  'skills/instantcms-debug/SKILL.md',
+  'skills/instantcms-security/SKILL.md',
 ];
 
 for (const path of required) {

--- a/skills/instantcms-api/SKILL.md
+++ b/skills/instantcms-api/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: instantcms-api
+description: Design, implement, or audit InstantCMS REST endpoints, external API clients, OAuth, webhooks, and authentication boundaries.
+---
+
+# InstantCMS API
+
+Choose between an InstantCMS endpoint, outbound client, webhook, and OAuth integration before generating code. Use the matching scaffold tool and confirm every framework method with `get_component_api`.
+
+Define authentication, permissions, validation, rate limits, timeouts, retries, and error shapes explicitly. Never log secrets or interpolate untrusted values into SQL, URLs, PHP, or response HTML.
+
+Run `audit_instantcms_project` and syntax validation after generation.

--- a/skills/instantcms-debug/SKILL.md
+++ b/skills/instantcms-debug/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: instantcms-debug
+description: Diagnose InstantCMS addon failures, installation errors, missing hooks, routes, templates, forms, database behavior, and runtime regressions.
+---
+
+# InstantCMS debug
+
+Reproduce the smallest failing path and collect the exact error, request route, relevant files, InstantCMS version, and database state. Use `explain_instantcms_project` before loading unrelated files.
+
+Run `audit_instantcms_project`, then inspect the specific hook, component API, route, or table implicated by evidence. Separate the root cause from secondary symptoms and do not modify code unless a fix was requested.
+
+For fixes, use `plan_project_changes`, return a reviewable patch, and re-run the original reproduction plus validation.

--- a/skills/instantcms-migration/SKILL.md
+++ b/skills/instantcms-migration/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: instantcms-migration
+description: Create, review, or repair InstantCMS database migrations, install SQL, schema changes, and reversible upgrade steps.
+---
+
+# InstantCMS migration
+
+Inspect the current schema and target version before proposing SQL. Use `introspect_database`, `describe_table`, and `scaffold_migration`; do not invent core table columns.
+
+Keep install, upgrade, and rollback behavior distinct. Preserve existing data, make repeated execution predictable where possible, and flag destructive changes before applying them.
+
+Validate the complete addon with `audit_instantcms_project` and verify install/uninstall on the target InstantCMS version before calling the migration ready.

--- a/skills/instantcms-security/SKILL.md
+++ b/skills/instantcms-security/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: instantcms-security
+description: Perform a focused security review of InstantCMS addons, APIs, templates, permissions, SQL, uploads, webhooks, and generated packages.
+---
+
+# InstantCMS security
+
+Use `audit_instantcms_project` as the baseline, then trace trust boundaries for request input, database writes, rendered output, files, URLs, credentials, and authorization decisions.
+
+Report exploitable findings separately from suspicious patterns. Include the affected path, data flow, impact, and smallest safe remediation. Do not claim a vulnerability from regex evidence alone.
+
+After an authorized fix, validate syntax, permissions, CSRF behavior, escaping context, archive paths, and regression tests.

--- a/skills/instantcms-theme/SKILL.md
+++ b/skills/instantcms-theme/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: instantcms-theme
+description: Build or modify InstantCMS themes, template overrides, layout schemes, widget positions, and frontend/backend templates.
+---
+
+# InstantCMS theme
+
+Start with `get_template_structure`, `list_template_overrides`, and `list_layout_presets`. Use the smallest override needed and preserve the active frontend theme as the location for backend content templates; `admincoreui` is the backend shell.
+
+Escape output for its HTML context and keep Bootstrap expectations compatible with the selected InstantCMS template. Validate YAML layout schemes and the complete project before delivery.

--- a/skills/instantcms-upgrade/SKILL.md
+++ b/skills/instantcms-upgrade/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: instantcms-upgrade
+description: Plan or execute an InstantCMS addon upgrade between framework versions while checking hooks, APIs, paths, migrations, and compatibility risks.
+---
+
+# InstantCMS upgrade
+
+Call `plan_instantcms_upgrade` with the complete project file map and exact source/target versions. Treat unknown methods as review candidates, not confirmed defects, until checked with `get_component_api`.
+
+Apply changes in reviewable groups: structure and paths, API calls, hooks, then migrations. Run `audit_instantcms_project` after each group and verify install/upgrade/uninstall on the target version.

--- a/skills/instantcms-widget/SKILL.md
+++ b/skills/instantcms-widget/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: instantcms-widget
+description: Create or modify InstantCMS widgets, their option forms, templates, caching, and controller integration.
+---
+
+# InstantCMS widget
+
+Use `list_widgets` and `get_widget_info` to inspect established patterns, then `scaffold_widget` for the initial structure. Look up unfamiliar fields and component methods rather than guessing.
+
+Keep option names aligned across the widget class, options form, and template. Treat cached output carefully when it depends on the current user or permissions.
+
+Finish with `audit_instantcms_project` and `validate_generated_artifacts`.

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -12,6 +12,9 @@ describe('MCP integration', () => {
       const listed = await client.listTools();
       expect(listed.tools.some(tool => tool.name === 'get_server_capabilities')).toBe(true);
       expect(listed.tools.some(tool => tool.name === 'validate_generated_artifacts')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'audit_instantcms_project')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'plan_instantcms_upgrade')).toBe(true);
+      expect(listed.tools).toHaveLength(86);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
       expect(result.structuredContent).toMatchObject({ server_version: '1.2.0' });
     } finally {

--- a/src/__tests__/project-workflows.test.ts
+++ b/src/__tests__/project-workflows.test.ts
@@ -1,0 +1,40 @@
+import {
+  auditInstantCmsProject,
+  explainInstantCmsProject,
+  planInstantCmsUpgrade,
+  planProjectChanges,
+  repairInstantCmsProject,
+} from '../tools/project-workflow-tool.js';
+
+const files = {
+  'system/controllers/demo/manifest.xml':
+    '<component><name>demo</name><title>Demo</title></component>',
+  'system/controllers/demo/frontend.php': '<?php class demo extends cmsFrontend {}',
+  'system/controllers/demo/languages/ru/demo.php': '<?php define("LANG_DEMO", "Demo");',
+  'system/controllers/demo/actions/index.php': '<?php echo $title;',
+};
+
+describe('project agent workflows', () => {
+  test('audits structure, syntax and suspicious output', () => {
+    const result = auditInstantCmsProject(files);
+    expect(result.kind).toBe('addon');
+    expect(result.diagnostics.some(item => item.code === 'MISPLACED_LANGUAGE_FILE')).toBe(true);
+    expect(result.diagnostics.some(item => item.code === 'POSSIBLE_UNESCAPED_OUTPUT')).toBe(true);
+  });
+
+  test('plans before applying only safe repairs', () => {
+    const plan = planProjectChanges(files);
+    expect(plan.safe_operations).toBe(1);
+    const repaired = repairInstantCmsProject(files);
+    expect(repaired.applied).toHaveLength(1);
+    expect(repaired.files['system/languages/ru/controllers/demo/demo.php']).toBeDefined();
+    expect(repaired.files['system/controllers/demo/languages/ru/demo.php']).toBeUndefined();
+  });
+
+  test('explains project and creates an upgrade checklist', () => {
+    expect(explainInstantCmsProject(files).controllers).toContain('demo');
+    const upgrade = planInstantCmsUpgrade(files, '2.17', '2.18.2');
+    expect(upgrade.comparison.to?.version).toBe('2.18.2');
+    expect(upgrade.checklist.length).toBeGreaterThan(2);
+  });
+});

--- a/src/data/version-profiles.ts
+++ b/src/data/version-profiles.ts
@@ -7,10 +7,16 @@ export interface InstantCmsVersionProfile {
 
 export const instantCmsVersionProfiles: InstantCmsVersionProfile[] = [
   {
-    version: '2.18.1',
+    version: '2.18.2',
     php_min: '7.2',
     status: 'verified',
-    notes: ['Основной профиль встроенной базы знаний'],
+    notes: ['Текущий профиль source-backed базы знаний'],
+  },
+  {
+    version: '2.18.1',
+    php_min: '7.2',
+    status: 'compatible',
+    notes: ['Предыдущий стабильный профиль; обновитесь до 2.18.2'],
   },
   {
     version: '2.17',

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -33,6 +33,19 @@ const workflows = {
     'validate_generated_artifacts',
     'inspect_addon_archive',
   ],
+  repair: [
+    'explain_instantcms_project',
+    'audit_instantcms_project',
+    'plan_project_changes',
+    'repair_instantcms_project',
+    'audit_instantcms_project',
+  ],
+  upgrade: [
+    'explain_instantcms_project',
+    'plan_instantcms_upgrade',
+    'plan_project_changes',
+    'audit_instantcms_project',
+  ],
 };
 
 const toolCatalog = [
@@ -56,6 +69,11 @@ const toolCatalog = [
     keywords: ['template', 'шаблон', 'layout', 'widget'],
     tools: workflows.template,
   },
+  {
+    category: 'project',
+    keywords: ['project', 'проект', 'audit', 'аудит', 'repair', 'исправ', 'upgrade', 'обнов'],
+    tools: [...workflows.repair, 'plan_instantcms_upgrade'],
+  },
 ];
 
 export function registerMetaTools(server: McpServer): void {
@@ -66,7 +84,7 @@ export function registerMetaTools(server: McpServer): void {
     async () =>
       successResult({
         server_version: '1.2.0',
-        tools_count: 81,
+        tools_count: 86,
         instantcms_profiles: instantCmsVersionProfiles,
         knowledge: {
           hooks: hooks.length,
@@ -93,7 +111,7 @@ export function registerMetaTools(server: McpServer): void {
   server.tool(
     'get_workflow',
     'Возвращает рекомендуемую последовательность инструментов',
-    { workflow: z.enum(['addon', 'widget', 'template', 'audit']) },
+    { workflow: z.enum(['addon', 'widget', 'template', 'audit', 'repair', 'upgrade']) },
     async ({ workflow }) => successResult({ workflow, tools: workflows[workflow] })
   );
 
@@ -110,7 +128,11 @@ export function registerMetaTools(server: McpServer): void {
             ? 'template'
             : lower.includes('провер') || lower.includes('audit')
               ? 'audit'
-              : 'addon';
+              : lower.includes('обнов') || lower.includes('upgrade')
+                ? 'upgrade'
+                : lower.includes('исправ') || lower.includes('repair')
+                  ? 'repair'
+                  : 'addon';
       return successResult({ workflow, tools: workflows[workflow] });
     }
   );
@@ -147,7 +169,7 @@ export function registerMetaTools(server: McpServer): void {
       successResult({
         status: 'ready',
         server_version: '1.2.0',
-        tested_instantcms: '2.18.1',
+        tested_instantcms: '2.18.2',
         checks: ['npm run check', 'npm run test:integration', 'npm run build', 'npm audit'],
       })
   );

--- a/src/registry/project-tools.ts
+++ b/src/registry/project-tools.ts
@@ -1,0 +1,47 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  auditInstantCmsProject,
+  explainInstantCmsProject,
+  planInstantCmsUpgrade,
+  planProjectChanges,
+  repairInstantCmsProject,
+} from '../tools/project-workflow-tool.js';
+import { successResult } from '../utils/mcp-result.js';
+
+const filesSchema = z
+  .record(z.string(), z.string())
+  .refine(files => Object.keys(files).length <= 2000);
+
+export function registerProjectTools(server: McpServer): void {
+  server.tool(
+    'audit_instantcms_project',
+    'Аудит существующего InstantCMS project file map',
+    { files: filesSchema },
+    async ({ files }) => successResult(auditInstantCmsProject(files))
+  );
+  server.tool(
+    'plan_project_changes',
+    'Строит план исправлений после аудита без изменения файлов',
+    { files: filesSchema },
+    async ({ files }) => successResult(planProjectChanges(files))
+  );
+  server.tool(
+    'repair_instantcms_project',
+    'Применяет только безопасные структурные исправления и возвращает новый file map',
+    { files: filesSchema },
+    async ({ files }) => successResult(repairInstantCmsProject(files))
+  );
+  server.tool(
+    'explain_instantcms_project',
+    'Кратко объясняет структуру существующего InstantCMS проекта',
+    { files: filesSchema },
+    async ({ files }) => successResult(explainInstantCmsProject(files))
+  );
+  server.tool(
+    'plan_instantcms_upgrade',
+    'Планирует обновление проекта между версиями InstantCMS',
+    { files: filesSchema, from: z.string().min(2).max(30), to: z.string().min(2).max(30) },
+    async ({ files, from, to }) => successResult(planInstantCmsUpgrade(files, from, to))
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { registerSourceTools } from './registry/source-tools.js';
 import { registerLanguageTools } from './registry/language-tools.js';
 import { registerExtensionTools } from './registry/extension-tools.js';
 import { registerResources } from './registry/resources.js';
+import { registerProjectTools } from './registry/project-tools.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -24,6 +25,7 @@ export function createServer(): McpServer {
   registerLanguageTools(server);
   registerExtensionTools(server);
   registerResources(server);
+  registerProjectTools(server);
 
   return server;
 }

--- a/src/tools/project-workflow-tool.ts
+++ b/src/tools/project-workflow-tool.ts
@@ -1,0 +1,209 @@
+import { validateAddon } from './addon-tool.js';
+import { validateGeneratedArtifacts, type ArtifactDiagnostic } from './artifact-tool.js';
+import { compareVersionProfiles } from '../data/version-profiles.js';
+import { components } from '../data/components.js';
+import { hooks } from '../data/hooks.js';
+
+export interface ProjectDiagnostic extends ArtifactDiagnostic {
+  suggestion?: string;
+}
+
+export interface ProjectOperation {
+  kind: 'create' | 'move' | 'replace' | 'review';
+  path: string;
+  target?: string;
+  reason: string;
+  safe: boolean;
+}
+
+function normalizeFiles(files: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(files).map(([filePath, content]) => [
+      filePath.replace(/\\/g, '/').replace(/^\.\//, ''),
+      content,
+    ])
+  );
+}
+
+function projectKind(files: Record<string, string>): 'addon' | 'template' | 'widget' | 'unknown' {
+  const paths = Object.keys(files);
+  if (paths.some(file => /(?:^|\/)manifest\.xml$/.test(file))) return 'addon';
+  if (paths.some(file => /(?:^|\/)widgets?\//.test(file))) return 'widget';
+  if (paths.some(file => /(?:^|\/)templates?\//.test(file))) return 'template';
+  return 'unknown';
+}
+
+function securityDiagnostics(files: Record<string, string>): ProjectDiagnostic[] {
+  const diagnostics: ProjectDiagnostic[] = [];
+  for (const [filePath, content] of Object.entries(files)) {
+    if (!filePath.endsWith('.php')) continue;
+    if (/->query\(\s*["'`][^"'`]*\$[a-z_]/i.test(content)) {
+      diagnostics.push({
+        code: 'POSSIBLE_SQL_INTERPOLATION',
+        severity: 'warning',
+        path: filePath,
+        message: 'SQL-запрос содержит интерполяцию переменной.',
+        suggestion: 'Используйте query builder или параметризованный запрос.',
+      });
+    }
+    if (/\becho\s+\$(?:_GET|_POST|_REQUEST|[a-z_]\w*)\s*;/i.test(content)) {
+      diagnostics.push({
+        code: 'POSSIBLE_UNESCAPED_OUTPUT',
+        severity: 'warning',
+        path: filePath,
+        message: 'Переменная выводится без видимого контекстного экранирования.',
+        suggestion: 'Проверьте происхождение значения и примените HTML escaping в шаблоне.',
+      });
+    }
+    if (/class\s+\w+\s+extends\s+cmsGrid\b/.test(content)) {
+      diagnostics.push({
+        code: 'LEGACY_CMSGRID_CLASS',
+        severity: 'error',
+        path: filePath,
+        message: 'Backend grid должен быть функцией grid_*, а не классом cmsGrid.',
+        suggestion: 'Перенесите конфигурацию в функцию backend/grids/grid_*.php.',
+      });
+    }
+  }
+  return diagnostics;
+}
+
+function pathDiagnostics(files: Record<string, string>): ProjectDiagnostic[] {
+  return Object.keys(files).flatMap(filePath => {
+    if (/controllers\/[^/]+\/languages\//.test(filePath)) {
+      return [
+        {
+          code: 'MISPLACED_LANGUAGE_FILE',
+          severity: 'error' as const,
+          path: filePath,
+          message: 'Language files должны находиться вне каталога контроллера.',
+          suggestion: 'Переместите файл в system/languages/{lang}/controllers/{name}/.',
+        },
+      ];
+    }
+    return [];
+  });
+}
+
+export function auditInstantCmsProject(filesInput: Record<string, string>) {
+  const files = normalizeFiles(filesInput);
+  const kind = projectKind(files);
+  const artifact = validateGeneratedArtifacts(files);
+  const addon = kind === 'addon' ? validateAddon(files) : null;
+  const addonDiagnostics: ProjectDiagnostic[] = addon
+    ? (
+        (
+          addon as {
+            diagnostics?: Array<{
+              code: string;
+              severity: 'error' | 'warning' | 'tip';
+              path?: string;
+              message: string;
+            }>;
+          }
+        ).diagnostics ?? []
+      )
+        .filter(
+          (item): item is typeof item & { severity: 'error' | 'warning' } =>
+            item.severity === 'error' || item.severity === 'warning'
+        )
+        .map(item => ({ ...item, path: item.path ?? '' }))
+    : [];
+  const diagnostics: ProjectDiagnostic[] = [
+    ...artifact.diagnostics,
+    ...addonDiagnostics,
+    ...pathDiagnostics(files),
+    ...securityDiagnostics(files),
+  ];
+  return {
+    kind,
+    files_checked: Object.keys(files).length,
+    is_valid: !diagnostics.some(item => item.severity === 'error'),
+    summary: {
+      errors: diagnostics.filter(item => item.severity === 'error').length,
+      warnings: diagnostics.filter(item => item.severity === 'warning').length,
+    },
+    diagnostics,
+  };
+}
+
+export function planProjectChanges(files: Record<string, string>) {
+  const audit = auditInstantCmsProject(files);
+  const operations: ProjectOperation[] = audit.diagnostics.map(diagnostic => ({
+    kind: diagnostic.code === 'MISPLACED_LANGUAGE_FILE' ? 'move' : 'review',
+    path: diagnostic.path,
+    target:
+      diagnostic.code === 'MISPLACED_LANGUAGE_FILE'
+        ? diagnostic.path.replace(
+            /controllers\/([^/]+)\/languages\/([^/]+)\//,
+            'languages/$2/controllers/$1/'
+          )
+        : undefined,
+    reason: diagnostic.suggestion ?? diagnostic.message,
+    safe: diagnostic.code === 'MISPLACED_LANGUAGE_FILE',
+  }));
+  return { audit, operations, safe_operations: operations.filter(item => item.safe).length };
+}
+
+export function repairInstantCmsProject(filesInput: Record<string, string>) {
+  const files = normalizeFiles(filesInput);
+  const plan = planProjectChanges(files);
+  const applied: ProjectOperation[] = [];
+  for (const operation of plan.operations) {
+    if (operation.kind !== 'move' || !operation.safe || !operation.target) continue;
+    if (!(operation.path in files) || operation.target in files) continue;
+    files[operation.target] = files[operation.path];
+    delete files[operation.path];
+    applied.push(operation);
+  }
+  return { files, applied, remaining: auditInstantCmsProject(files) };
+}
+
+export function explainInstantCmsProject(files: Record<string, string>) {
+  const normalized = normalizeFiles(files);
+  const paths = Object.keys(normalized);
+  return {
+    kind: projectKind(normalized),
+    files: paths.length,
+    controllers: [...new Set(paths.flatMap(path => path.match(/controllers\/([^/]+)/)?.[1] ?? []))],
+    hooks: paths.filter(path => /\/hooks\/[^/]+\.php$/.test(path)),
+    actions: paths.filter(path => /\/actions\/[^/]+\.php$/.test(path)),
+    forms: paths.filter(path => /\/forms\/[^/]+\.php$/.test(path)),
+    templates: paths.filter(path => /\.tpl\.php$/.test(path)),
+    languages: paths.filter(path => /(?:^|\/)languages\//.test(path)),
+  };
+}
+
+export function planInstantCmsUpgrade(files: Record<string, string>, from: string, to: string) {
+  const comparison = compareVersionProfiles(from, to);
+  const audit = auditInstantCmsProject(files);
+  const code = Object.values(files).join('\n');
+  const referencedHooks = [
+    ...new Set([...code.matchAll(/['"]([a-z][a-z0-9_]+)['"]/g)].map(m => m[1])),
+  ]
+    .filter(name => name.includes('_'))
+    .filter(name => hooks.some(hook => hook.name === name));
+  const referencedMethods = [
+    ...new Set([...code.matchAll(/->([a-zA-Z_]\w*)\s*\(/g)].map(m => m[1])),
+  ];
+  const knownMethods = new Set(
+    components.flatMap(component => component.methods.map(method => method.name))
+  );
+  const unknownMethods = referencedMethods.filter(method => !knownMethods.has(method));
+  return {
+    from,
+    to,
+    comparison,
+    audit,
+    compatibility: {
+      referenced_hooks: referencedHooks,
+      unknown_method_candidates: unknownMethods,
+    },
+    checklist: [
+      'Повторно проверьте manifest.xml и minimum supported version.',
+      'Запустите audit_instantcms_project после изменений.',
+      'Проверьте install/uninstall на чистой целевой InstantCMS.',
+      'Перепроверьте hooks и методы с unknown_method_candidates вручную.',
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- add project audit, explanation, repair planning, safe repair, and upgrade planning tools
- add focused migration, widget, theme, API, upgrade, debug, and security skills
- update MCP metadata, tests, architecture, changelog, and README

## Validation
- npm run check
- npm run test:integration
- npm run build
- npm audit --audit-level=high
- validate all InstantCMS skill frontmatter with the project YAML parser