### PR TITLE
Load projects and generate unified patches

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 - `src/server.ts` is the composition root: it creates the MCP server and invokes domain registrars.
 - `src/registry/` owns transport-facing Zod schemas and tool/resource registration, split into generators, knowledge, database, source analysis, language, extensions, metadata, and resources.
-- `src/registry/project-tools.ts` exposes read-only project analysis, reviewable repair planning, safe file-map transformations, and version upgrade planning.
+- `src/registry/project-tools.ts` exposes bounded local/GitHub project loading, read-only analysis, reviewable repair planning, unified patch generation, safe file-map transformations, and version upgrade planning.
 - `src/utils/mcp-result.ts` задаёт единый `content + structuredContent + isError` контракт.
 - `src/utils/pagination.ts` реализует cursor pagination для больших справочников.
 - `src/tools/` contains deterministic domain operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Expose source file provenance for discovered hooks and components.
 - Add project audit, explain, plan, safe repair, and version upgrade MCP workflows.
 - Add focused migration, widget, theme, API, upgrade, debug, and security skills.
+- Add bounded project loading from local directories and public GitHub repositories.
+- Generate unified Git patches directly and include them in safe project repair results.
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 - диагностические коды для автоматического исправления;
 - экранирование пользовательских данных для XML, INI, PHP и YAML;
 - AI-инструкции и skills без дублирования базы знаний.
-- 86 MCP-инструментов и четыре встроенных MCP resource;
+- 88 MCP-инструментов и четыре встроенных MCP resource;
 - воспроизводимая генерация runtime-справочников из зафиксированного commit InstantCMS;
 - автоматическая еженедельная проверка обновлений и Pull Request с изменившимися данными;
 - CI на Node.js 18, 20, 22 и 24 с отдельной проверкой официальных исходников InstantCMS.
@@ -65,7 +65,7 @@ npm run check
 
 ## Основные MCP-инструменты
 
-Сервер регистрирует 86 инструментов. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, templates, аудит существующих проектов и планирование обновлений.
+Сервер регистрирует 88 инструментов. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, templates, загрузку и аудит существующих проектов, patch generation и планирование обновлений.
 
 | Инструмент                                      | Назначение                                      |
 | ----------------------------------------------- | ----------------------------------------------- |
@@ -94,6 +94,8 @@ npm run check
 | `repair_instantcms_project`                     | Только безопасные структурные исправления       |
 | `explain_instantcms_project`                    | Краткая карта существующего проекта             |
 | `plan_instantcms_upgrade`                       | План обновления между версиями InstantCMS       |
+| `load_instantcms_project`                       | Загрузка проекта из директории или GitHub       |
+| `create_project_patch`                          | Unified Git patch между двумя file map          |
 
 Сервер также публикует MCP resources со всеми хуками, компонентами, типами дополнений и quickstart.
 
@@ -108,7 +110,7 @@ npm run check
 | `source-tools`    |         12 | widgets, traits, fields, routes, миграции и анализ требований                    |
 | `language-tools`  |          3 | языковые ключи, language files и migration scaffold                              |
 | `extension-tools` |         17 | WYSIWYG, permissions, filters, SEO, import/export, cache, webhooks, OAuth и темы |
-| `project-tools`   |          5 | аудит, объяснение проекта, план, безопасный repair и upgrade planner             |
+| `project-tools`   |          7 | загрузка, аудит, объяснение, план, безопасный repair, patch и upgrade planner    |
 
 Полные имена, входные Zod-схемы и описания доступны клиенту через стандартный MCP `tools/list`. Для начала неизвестной задачи используйте `diagnose_request`, `find_tool` или `get_workflow`.
 
@@ -192,7 +194,9 @@ Skills разделены по workflow:
 - `skills/instantcms-debug` — диагностика runtime и installation failures;
 - `skills/instantcms-security` — целевой security review.
 
-Для существующего проекта рекомендуемый агентный цикл: `explain_instantcms_project → audit_instantcms_project → plan_project_changes → review → repair_instantcms_project → audit_instantcms_project`. Инструмент repair возвращает новый file map и не записывает файлы самостоятельно.
+Для существующего проекта рекомендуемый агентный цикл: `load_instantcms_project → explain_instantcms_project → audit_instantcms_project → plan_project_changes → review → repair_instantcms_project → create_project_patch → audit_instantcms_project`. Инструмент repair сразу возвращает новый file map и unified Git patch, но не записывает файлы самостоятельно.
+
+Локальный loader рекурсивно читает только текстовые файлы, не следует по symbolic links и пропускает `.git`, `node_modules`, `vendor`, сборочные каталоги и бинарные данные. GitHub loader принимает `owner/repository` или URL публичного репозитория, точный `ref` и необязательный `subpath`. Для обоих источников действуют ограничения количества файлов, размера одного файла и общего объёма.
 
 Большие справочники не копируются в skills. Агент получает факты через MCP tools/resources и `knowledge/`, а skill определяет порядок работы и критерии готовности.
 

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -14,7 +14,9 @@ describe('MCP integration', () => {
       expect(listed.tools.some(tool => tool.name === 'validate_generated_artifacts')).toBe(true);
       expect(listed.tools.some(tool => tool.name === 'audit_instantcms_project')).toBe(true);
       expect(listed.tools.some(tool => tool.name === 'plan_instantcms_upgrade')).toBe(true);
-      expect(listed.tools).toHaveLength(86);
+      expect(listed.tools.some(tool => tool.name === 'load_instantcms_project')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'create_project_patch')).toBe(true);
+      expect(listed.tools).toHaveLength(88);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
       expect(result.structuredContent).toMatchObject({ server_version: '1.2.0' });
     } finally {

--- a/src/__tests__/project-source.test.ts
+++ b/src/__tests__/project-source.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { zipSync } from 'fflate';
+import { loadGithubProject, loadLocalProject } from '../tools/project-source-tool.js';
+
+describe('project sources', () => {
+  test('loads local text files while ignoring dependencies and symlinks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'instantcms-mcp-'));
+    try {
+      await mkdir(join(root, 'system/controllers/demo'), { recursive: true });
+      await mkdir(join(root, 'node_modules/pkg'), { recursive: true });
+      await writeFile(join(root, 'system/controllers/demo/frontend.php'), '<?php');
+      await writeFile(join(root, 'node_modules/pkg/index.js'), 'ignored');
+      await symlink(join(root, 'system/controllers/demo/frontend.php'), join(root, 'linked.php'));
+      const result = await loadLocalProject(root);
+      expect(result.files).toEqual({ 'system/controllers/demo/frontend.php': '<?php' });
+      expect(result.skipped).toContainEqual({ path: 'linked.php', reason: 'symbolic_link' });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('loads a selected directory from a GitHub archive', async () => {
+    const archive = zipSync({
+      'repo-main/addons/demo/manifest.xml': new TextEncoder().encode('<component/>'),
+      'repo-main/README.md': new TextEncoder().encode('ignored'),
+    });
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn(async () => new Response(archive, { status: 200 })) as typeof fetch;
+    try {
+      const result = await loadGithubProject('owner/repo', 'main', 'addons/demo');
+      expect(result.files).toEqual({ 'manifest.xml': '<component/>' });
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://codeload.github.com/owner/repo/zip/main',
+        expect.objectContaining({ redirect: 'error' })
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('rejects invalid GitHub repository input', async () => {
+    await expect(loadGithubProject('https://example.com/owner/repo')).rejects.toThrow(
+      'Repository must be owner/name'
+    );
+  });
+});

--- a/src/__tests__/project-workflows.test.ts
+++ b/src/__tests__/project-workflows.test.ts
@@ -5,6 +5,8 @@ import {
   planProjectChanges,
   repairInstantCmsProject,
 } from '../tools/project-workflow-tool.js';
+import { createProjectPatch } from '../tools/project-patch-tool.js';
+import { spawnSync } from 'node:child_process';
 
 const files = {
   'system/controllers/demo/manifest.xml':
@@ -29,6 +31,33 @@ describe('project agent workflows', () => {
     expect(repaired.applied).toHaveLength(1);
     expect(repaired.files['system/languages/ru/controllers/demo/demo.php']).toBeDefined();
     expect(repaired.files['system/controllers/demo/languages/ru/demo.php']).toBeUndefined();
+    expect(repaired.patch.patch).toContain(
+      'rename from system/controllers/demo/languages/ru/demo.php'
+    );
+  });
+
+  test('creates an applicable unified patch for edits and additions', () => {
+    const result = createProjectPatch(
+      { 'a.php': '<?php echo 1;\n' },
+      { 'a.php': '<?php echo 2;\n', 'b.php': '<?php\n' }
+    );
+    expect(result.changed_files).toBe(2);
+    expect(result.patch).toContain('diff --git a/a.php b/a.php');
+    expect(result.patch).toContain('-<?php echo 1;');
+    expect(result.patch).toContain('+<?php echo 2;');
+    expect(result.patch).toContain('new file mode 100644');
+    const parsed = spawnSync('git', ['apply', '--numstat', '-'], {
+      input: result.patch,
+      encoding: 'utf8',
+    });
+    expect(parsed.status).toBe(0);
+    expect(parsed.stdout).toContain('a.php');
+  });
+
+  test('rejects unsafe patch paths', () => {
+    expect(() => createProjectPatch({ '../secret.php': 'secret' }, {})).toThrow(
+      'Unsafe project path'
+    );
   });
 
   test('explains project and creates an upgrade checklist', () => {

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -34,10 +34,12 @@ const workflows = {
     'inspect_addon_archive',
   ],
   repair: [
+    'load_instantcms_project',
     'explain_instantcms_project',
     'audit_instantcms_project',
     'plan_project_changes',
     'repair_instantcms_project',
+    'create_project_patch',
     'audit_instantcms_project',
   ],
   upgrade: [
@@ -84,7 +86,7 @@ export function registerMetaTools(server: McpServer): void {
     async () =>
       successResult({
         server_version: '1.2.0',
-        tools_count: 86,
+        tools_count: 88,
         instantcms_profiles: instantCmsVersionProfiles,
         knowledge: {
           hooks: hooks.length,

--- a/src/registry/project-tools.ts
+++ b/src/registry/project-tools.ts
@@ -8,12 +8,58 @@ import {
   repairInstantCmsProject,
 } from '../tools/project-workflow-tool.js';
 import { successResult } from '../utils/mcp-result.js';
+import { createProjectPatch } from '../tools/project-patch-tool.js';
+import { loadGithubProject, loadLocalProject } from '../tools/project-source-tool.js';
 
 const filesSchema = z
   .record(z.string(), z.string())
   .refine(files => Object.keys(files).length <= 2000);
 
+const loadLimitsSchema = {
+  max_files: z.number().int().min(1).max(5000).optional(),
+  max_file_bytes: z
+    .number()
+    .int()
+    .min(1024)
+    .max(5 * 1024 * 1024)
+    .optional(),
+  max_total_bytes: z
+    .number()
+    .int()
+    .min(1024)
+    .max(50 * 1024 * 1024)
+    .optional(),
+};
+
 export function registerProjectTools(server: McpServer): void {
+  server.tool(
+    'load_instantcms_project',
+    'Загружает текстовые файлы проекта из локальной директории или публичного GitHub-репозитория',
+    {
+      source: z.discriminatedUnion('type', [
+        z.object({ type: z.literal('local'), path: z.string().min(1), ...loadLimitsSchema }),
+        z.object({
+          type: z.literal('github'),
+          repository: z.string().min(3),
+          ref: z.string().min(1).default('main'),
+          subpath: z.string().default(''),
+          ...loadLimitsSchema,
+        }),
+      ]),
+    },
+    async ({ source }) =>
+      successResult(
+        source.type === 'local'
+          ? await loadLocalProject(source.path, source)
+          : await loadGithubProject(source.repository, source.ref, source.subpath, source)
+      )
+  );
+  server.tool(
+    'create_project_patch',
+    'Создаёт стандартный unified Git patch между двумя project file map',
+    { before: filesSchema, after: filesSchema },
+    async ({ before, after }) => successResult(createProjectPatch(before, after))
+  );
   server.tool(
     'audit_instantcms_project',
     'Аудит существующего InstantCMS project file map',

--- a/src/tools/project-patch-tool.ts
+++ b/src/tools/project-patch-tool.ts
@@ -1,0 +1,105 @@
+function splitLines(content: string): string[] {
+  if (!content) return [];
+  const lines = content.split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  return lines;
+}
+
+function patchBody(oldContent: string, newContent: string): string[] {
+  const oldLines = splitLines(oldContent);
+  const newLines = splitLines(newContent);
+  const removed = oldLines.map(line => `-${line}`);
+  const added = newLines.map(line => `+${line}`);
+  if (oldContent && !oldContent.endsWith('\n')) removed.push('\\ No newline at end of file');
+  if (newContent && !newContent.endsWith('\n')) added.push('\\ No newline at end of file');
+  return [
+    `@@ -${oldLines.length ? `1,${oldLines.length}` : '0,0'} +${newLines.length ? `1,${newLines.length}` : '0,0'} @@`,
+    ...removed,
+    ...added,
+  ];
+}
+
+function header(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (
+    !normalized ||
+    normalized.startsWith('/') ||
+    /[\r\n\0]/.test(normalized) ||
+    normalized.split('/').some(part => part === '..')
+  ) {
+    throw new Error(`Unsafe project path: ${path}`);
+  }
+  return normalized;
+}
+
+export function createProjectPatch(
+  beforeInput: Record<string, string>,
+  afterInput: Record<string, string>
+) {
+  const before = Object.fromEntries(
+    Object.entries(beforeInput).map(([path, value]) => [header(path), value])
+  );
+  const after = Object.fromEntries(
+    Object.entries(afterInput).map(([path, value]) => [header(path), value])
+  );
+  const removed = Object.keys(before).filter(path => !(path in after));
+  const added = Object.keys(after).filter(path => !(path in before));
+  const renamed = new Map<string, string>();
+
+  for (const oldPath of removed) {
+    const newPath = added.find(
+      path => ![...renamed.values()].includes(path) && after[path] === before[oldPath]
+    );
+    if (newPath) renamed.set(oldPath, newPath);
+  }
+
+  const chunks: string[] = [];
+  for (const [oldPath, newPath] of [...renamed].sort(([a], [b]) => a.localeCompare(b))) {
+    chunks.push(
+      `diff --git a/${oldPath} b/${newPath}`,
+      'similarity index 100%',
+      `rename from ${oldPath}`,
+      `rename to ${newPath}`
+    );
+  }
+  for (const path of removed.filter(item => !renamed.has(item)).sort()) {
+    chunks.push(
+      `diff --git a/${path} b/${path}`,
+      'deleted file mode 100644',
+      `--- a/${path}`,
+      '+++ /dev/null',
+      ...patchBody(before[path], '')
+    );
+  }
+  for (const path of added.filter(item => ![...renamed.values()].includes(item)).sort()) {
+    chunks.push(
+      `diff --git a/${path} b/${path}`,
+      'new file mode 100644',
+      '--- /dev/null',
+      `+++ b/${path}`,
+      ...patchBody('', after[path])
+    );
+  }
+  for (const path of Object.keys(before)
+    .filter(path => path in after && before[path] !== after[path])
+    .sort()) {
+    chunks.push(
+      `diff --git a/${path} b/${path}`,
+      `--- a/${path}`,
+      `+++ b/${path}`,
+      ...patchBody(before[path], after[path])
+    );
+  }
+
+  const patch = chunks.length ? `${chunks.join('\n')}\n` : '';
+  return {
+    patch,
+    changed_files:
+      removed.length +
+      added.length -
+      renamed.size +
+      Object.keys(before).filter(path => path in after && before[path] !== after[path]).length,
+    renames: Object.fromEntries(renamed),
+    is_empty: !patch,
+  };
+}

--- a/src/tools/project-source-tool.ts
+++ b/src/tools/project-source-tool.ts
@@ -1,0 +1,202 @@
+import { lstat, readdir, readFile, realpath } from 'node:fs/promises';
+import { relative, resolve, sep } from 'node:path';
+import { unzipSync } from 'fflate';
+
+const DEFAULT_MAX_FILES = 2000;
+const DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
+const DEFAULT_MAX_TOTAL_BYTES = 20 * 1024 * 1024;
+const ignoredDirectories = new Set(['.git', 'node_modules', 'vendor', 'dist', 'build', '.idea']);
+const textExtensions = new Set([
+  '.css',
+  '.html',
+  '.ini',
+  '.js',
+  '.json',
+  '.md',
+  '.php',
+  '.scss',
+  '.sql',
+  '.svg',
+  '.tpl',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.xml',
+  '.yaml',
+  '.yml',
+]);
+
+export interface ProjectLoadOptions {
+  max_files?: number;
+  max_file_bytes?: number;
+  max_total_bytes?: number;
+}
+
+function limits(options: ProjectLoadOptions) {
+  return {
+    maxFiles: options.max_files ?? DEFAULT_MAX_FILES,
+    maxFileBytes: options.max_file_bytes ?? DEFAULT_MAX_FILE_BYTES,
+    maxTotalBytes: options.max_total_bytes ?? DEFAULT_MAX_TOTAL_BYTES,
+  };
+}
+
+function isTextFile(path: string, bytes: Uint8Array): boolean {
+  const extension = path.includes('.') ? path.slice(path.lastIndexOf('.')).toLowerCase() : '';
+  if (
+    textExtensions.has(extension) ||
+    ['LICENSE', 'README', '.gitignore'].includes(path.split('/').at(-1) ?? '')
+  ) {
+    return !bytes.subarray(0, 8192).includes(0);
+  }
+  return false;
+}
+
+function assertWithinRoot(root: string, candidate: string): void {
+  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+    throw new Error(`Path escapes the requested project root: ${candidate}`);
+  }
+}
+
+export async function loadLocalProject(rootInput: string, options: ProjectLoadOptions = {}) {
+  const root = await realpath(resolve(rootInput));
+  if (!(await lstat(root)).isDirectory()) throw new Error('Local project path must be a directory');
+  const configured = limits(options);
+  const files: Record<string, string> = {};
+  const skipped: Array<{ path: string; reason: string }> = [];
+  let totalBytes = 0;
+
+  async function walk(directory: string): Promise<void> {
+    assertWithinRoot(root, directory);
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (entry.isSymbolicLink()) {
+        skipped.push({
+          path: relative(root, resolve(directory, entry.name)),
+          reason: 'symbolic_link',
+        });
+        continue;
+      }
+      if (entry.isDirectory() && ignoredDirectories.has(entry.name)) continue;
+      const absolute = resolve(directory, entry.name);
+      assertWithinRoot(root, absolute);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const path = relative(root, absolute).split(sep).join('/');
+      const bytes = await readFile(absolute);
+      if (bytes.byteLength > configured.maxFileBytes) {
+        skipped.push({ path, reason: 'file_too_large' });
+        continue;
+      }
+      if (!isTextFile(path, bytes)) {
+        skipped.push({ path, reason: 'binary_or_unsupported' });
+        continue;
+      }
+      if (Object.keys(files).length >= configured.maxFiles)
+        throw new Error('Project file limit exceeded');
+      totalBytes += bytes.byteLength;
+      if (totalBytes > configured.maxTotalBytes)
+        throw new Error('Project total size limit exceeded');
+      files[path] = bytes.toString('utf8');
+    }
+  }
+
+  await walk(root);
+  return {
+    source: 'local' as const,
+    root,
+    files,
+    files_loaded: Object.keys(files).length,
+    total_bytes: totalBytes,
+    skipped,
+  };
+}
+
+function validateGithubPart(value: string, label: string): string {
+  if (!/^[A-Za-z0-9._/-]+$/.test(value) || value.includes('..') || value.startsWith('/')) {
+    throw new Error(`Invalid GitHub ${label}`);
+  }
+  return value;
+}
+
+export async function loadGithubProject(
+  repository: string,
+  ref = 'main',
+  subpath = '',
+  options: ProjectLoadOptions = {}
+) {
+  const match = repository.match(
+    /^(?:https:\/\/github\.com\/)?([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/
+  );
+  if (!match)
+    throw new Error('Repository must be owner/name or an https://github.com/owner/name URL');
+  const owner = validateGithubPart(match[1], 'owner');
+  const name = validateGithubPart(match[2], 'repository');
+  const safeRef = validateGithubPart(ref, 'ref');
+  const safeSubpath = subpath
+    ? validateGithubPart(subpath.replace(/^\.\//, '').replace(/\/$/, ''), 'subpath')
+    : '';
+  const response = await fetch(
+    `https://codeload.github.com/${owner}/${name}/zip/${encodeURIComponent(safeRef)}`,
+    { headers: { 'user-agent': 'instantcms-mcp' }, redirect: 'error' }
+  );
+  if (!response.ok) throw new Error(`GitHub archive request failed: HTTP ${response.status}`);
+  const contentLength = Number(response.headers.get('content-length') ?? 0);
+  if (contentLength > 50 * 1024 * 1024) throw new Error('GitHub archive is too large');
+  const archive = new Uint8Array(await response.arrayBuffer());
+  if (archive.byteLength > 50 * 1024 * 1024) throw new Error('GitHub archive is too large');
+  const configured = limits(options);
+  const archiveRelativePath = (archivePath: string): string | null => {
+    const parts = archivePath.split('/').slice(1);
+    if (!parts.length || archivePath.endsWith('/')) return null;
+    const path = parts.join('/');
+    if (safeSubpath && path !== safeSubpath && !path.startsWith(`${safeSubpath}/`)) return null;
+    const relativePath = safeSubpath ? path.slice(safeSubpath.length).replace(/^\//, '') : path;
+    if (!relativePath || relativePath.split('/').some(part => ignoredDirectories.has(part)))
+      return null;
+    return relativePath;
+  };
+  let projectedFiles = 0;
+  let projectedBytes = 0;
+  const entries = unzipSync(archive, {
+    filter: file => {
+      if (!archiveRelativePath(file.name) || file.originalSize > configured.maxFileBytes)
+        return false;
+      projectedFiles += 1;
+      projectedBytes += file.originalSize;
+      if (projectedFiles > configured.maxFiles) throw new Error('Project file limit exceeded');
+      if (projectedBytes > configured.maxTotalBytes)
+        throw new Error('Project total size limit exceeded');
+      return true;
+    },
+  });
+  const files: Record<string, string> = {};
+  const skipped: Array<{ path: string; reason: string }> = [];
+  let totalBytes = 0;
+
+  for (const [archivePath, bytes] of Object.entries(entries)) {
+    const relativePath = archiveRelativePath(archivePath);
+    if (!relativePath) continue;
+    if (!isTextFile(relativePath, bytes)) {
+      skipped.push({ path: relativePath, reason: 'binary_or_unsupported' });
+      continue;
+    }
+    if (Object.keys(files).length >= configured.maxFiles)
+      throw new Error('Project file limit exceeded');
+    totalBytes += bytes.byteLength;
+    if (totalBytes > configured.maxTotalBytes) throw new Error('Project total size limit exceeded');
+    files[relativePath] = Buffer.from(bytes).toString('utf8');
+  }
+
+  return {
+    source: 'github' as const,
+    repository: `${owner}/${name}`,
+    ref: safeRef,
+    subpath: safeSubpath,
+    files,
+    files_loaded: Object.keys(files).length,
+    total_bytes: totalBytes,
+    skipped,
+  };
+}

--- a/src/tools/project-workflow-tool.ts
+++ b/src/tools/project-workflow-tool.ts
@@ -3,6 +3,7 @@ import { validateGeneratedArtifacts, type ArtifactDiagnostic } from './artifact-
 import { compareVersionProfiles } from '../data/version-profiles.js';
 import { components } from '../data/components.js';
 import { hooks } from '../data/hooks.js';
+import { createProjectPatch } from './project-patch-tool.js';
 
 export interface ProjectDiagnostic extends ArtifactDiagnostic {
   suggestion?: string;
@@ -146,7 +147,8 @@ export function planProjectChanges(files: Record<string, string>) {
 }
 
 export function repairInstantCmsProject(filesInput: Record<string, string>) {
-  const files = normalizeFiles(filesInput);
+  const before = normalizeFiles(filesInput);
+  const files = { ...before };
   const plan = planProjectChanges(files);
   const applied: ProjectOperation[] = [];
   for (const operation of plan.operations) {
@@ -156,7 +158,12 @@ export function repairInstantCmsProject(filesInput: Record<string, string>) {
     delete files[operation.path];
     applied.push(operation);
   }
-  return { files, applied, remaining: auditInstantCmsProject(files) };
+  return {
+    files,
+    applied,
+    patch: createProjectPatch(before, files),
+    remaining: auditInstantCmsProject(files),
+  };
 }
 
 export function explainInstantCmsProject(files: Record<string, string>) {


### PR DESCRIPTION
## Summary
- load bounded text-only projects from local directories or public GitHub repositories
- protect local traversal and GitHub archive extraction with symlink, path, file-count, and byte limits
- generate standard unified Git patches and include patches in repair results
- update workflows, MCP metadata, tests, architecture, changelog, and README

## Validation
- npm run check
- npm run test:integration
- npm run build
- npm run lint
- npm audit --audit-level=high
- generated patch parsed successfully by git apply --numstat