### PR TITLE
Expand template development workflows

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,6 +7,7 @@
 - `src/server.ts` is the composition root: it creates the MCP server and invokes domain registrars.
 - `src/registry/` owns transport-facing Zod schemas and tool/resource registration, split into generators, knowledge, database, source analysis, language, extensions, metadata, and resources.
 - `src/registry/project-tools.ts` exposes bounded local/GitHub project loading, read-only analysis, reviewable repair planning, unified patch generation, safe file-map transformations, and version upgrade planning.
+- `src/registry/template-development-tools.ts` owns complete theme scaffolding, existing-theme analysis, source-preserving overrides, layout validation, and upstream compatibility checks.
 - `src/utils/mcp-result.ts` задаёт единый `content + structuredContent + isError` контракт.
 - `src/utils/pagination.ts` реализует cursor pagination для больших справочников.
 - `src/tools/` contains deterministic domain operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add focused migration, widget, theme, API, upgrade, debug, and security skills.
 - Add bounded project loading from local directories and public GitHub repositories.
 - Generate unified Git patches directly and include them in safe project repair results.
+- Add complete template scaffolding, existing-theme analysis, source-preserving overrides, layout validation, and upstream override compatibility checks.
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 - диагностические коды для автоматического исправления;
 - экранирование пользовательских данных для XML, INI, PHP и YAML;
 - AI-инструкции и skills без дублирования базы знаний.
-- 88 MCP-инструментов и четыре встроенных MCP resource;
+- 93 MCP-инструмента и четыре встроенных MCP resource;
 - воспроизводимая генерация runtime-справочников из зафиксированного commit InstantCMS;
 - автоматическая еженедельная проверка обновлений и Pull Request с изменившимися данными;
 - CI на Node.js 18, 20, 22 и 24 с отдельной проверкой официальных исходников InstantCMS.
@@ -65,7 +65,7 @@ npm run check
 
 ## Основные MCP-инструменты
 
-Сервер регистрирует 88 инструментов. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, templates, загрузку и аудит существующих проектов, patch generation и планирование обновлений.
+Сервер регистрирует 93 инструмента. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, углублённую разработку шаблонов, загрузку и аудит существующих проектов, patch generation и планирование обновлений.
 
 | Инструмент                                      | Назначение                                      |
 | ----------------------------------------------- | ----------------------------------------------- |
@@ -96,21 +96,27 @@ npm run check
 | `plan_instantcms_upgrade`                       | План обновления между версиями InstantCMS       |
 | `load_instantcms_project`                       | Загрузка проекта из директории или GitHub       |
 | `create_project_patch`                          | Unified Git patch между двумя file map          |
+| `scaffold_complete_template`                    | Полный каркас темы и layout-схема               |
+| `analyze_instantcms_template`                   | Анализ структуры, позиций и overrides           |
+| `scaffold_template_override`                    | Override из upstream template-файла             |
+| `validate_layout_scheme`                        | Проверка YAML layout-схемы                      |
+| `check_template_override_compatibility`         | Проверка overrides при обновлении InstantCMS    |
 
 Сервер также публикует MCP resources со всеми хуками, компонентами, типами дополнений и quickstart.
 
 ### Группы инструментов
 
-| Registry          | Количество | Что входит                                                                       |
-| ----------------- | ---------: | -------------------------------------------------------------------------------- |
-| `meta-tools`      |         10 | capabilities, подбор workflow, диагностика, версии и артефакты                   |
-| `generator-tools` |         13 | addon, CRUD, формы, grid, REST API, тесты, email, cron и overrides               |
-| `knowledge-tools` |         20 | хуки, компоненты, поля, шаблоны, layout, БД и контроллеры                        |
-| `database-tools`  |          6 | безопасный доступ к MariaDB и исследование таблиц                                |
-| `source-tools`    |         12 | widgets, traits, fields, routes, миграции и анализ требований                    |
-| `language-tools`  |          3 | языковые ключи, language files и migration scaffold                              |
-| `extension-tools` |         17 | WYSIWYG, permissions, filters, SEO, import/export, cache, webhooks, OAuth и темы |
-| `project-tools`   |          7 | загрузка, аудит, объяснение, план, безопасный repair, patch и upgrade planner    |
+| Registry                     | Количество | Что входит                                                                       |
+| ---------------------------- | ---------: | -------------------------------------------------------------------------------- |
+| `meta-tools`                 |         10 | capabilities, подбор workflow, диагностика, версии и артефакты                   |
+| `generator-tools`            |         13 | addon, CRUD, формы, grid, REST API, тесты, email, cron и overrides               |
+| `knowledge-tools`            |         20 | хуки, компоненты, поля, шаблоны, layout, БД и контроллеры                        |
+| `database-tools`             |          6 | безопасный доступ к MariaDB и исследование таблиц                                |
+| `source-tools`               |         12 | widgets, traits, fields, routes, миграции и анализ требований                    |
+| `language-tools`             |          3 | языковые ключи, language files и migration scaffold                              |
+| `extension-tools`            |         17 | WYSIWYG, permissions, filters, SEO, import/export, cache, webhooks, OAuth и темы |
+| `project-tools`              |          7 | загрузка, аудит, объяснение, план, безопасный repair, patch и upgrade planner    |
+| `template-development-tools` |          5 | полный scaffold, анализ, overrides, layout validation и upgrade compatibility    |
 
 Полные имена, входные Zod-схемы и описания доступны клиенту через стандартный MCP `tools/list`. Для начала неизвестной задачи используйте `diagnose_request`, `find_tool` или `get_workflow`.
 
@@ -197,6 +203,8 @@ Skills разделены по workflow:
 Для существующего проекта рекомендуемый агентный цикл: `load_instantcms_project → explain_instantcms_project → audit_instantcms_project → plan_project_changes → review → repair_instantcms_project → create_project_patch → audit_instantcms_project`. Инструмент repair сразу возвращает новый file map и unified Git patch, но не записывает файлы самостоятельно.
 
 Локальный loader рекурсивно читает только текстовые файлы, не следует по symbolic links и пропускает `.git`, `node_modules`, `vendor`, сборочные каталоги и бинарные данные. GitHub loader принимает `owner/repository` или URL публичного репозитория, точный `ref` и необязательный `subpath`. Для обоих источников действуют ограничения количества файлов, размера одного файла и общего объёма.
+
+Для разработки темы используйте цикл `load_instantcms_project → analyze_instantcms_template → scaffold_complete_template/scaffold_template_override → validate_layout_scheme → create_project_patch → audit_instantcms_project`. Перед обновлением InstantCMS передайте старую и новую upstream-карты шаблонов в `check_template_override_compatibility`: инструмент отделит совместимые overrides от изменённых или удалённых upstream-файлов, требующих ручной проверки.
 
 Большие справочники не копируются в skills. Агент получает факты через MCP tools/resources и `knowledge/`, а skill определяет порядок работы и критерии готовности.
 

--- a/skills/instantcms-theme/SKILL.md
+++ b/skills/instantcms-theme/SKILL.md
@@ -5,6 +5,6 @@ description: Build or modify InstantCMS themes, template overrides, layout schem
 
 # InstantCMS theme
 
-Start with `get_template_structure`, `list_template_overrides`, and `list_layout_presets`. Use the smallest override needed and preserve the active frontend theme as the location for backend content templates; `admincoreui` is the backend shell.
+Start with `load_instantcms_project` and `analyze_instantcms_template`; use `get_template_structure` for framework rules. Create new themes with `scaffold_complete_template` and copy an exact upstream file with `scaffold_template_override` before making the smallest required override. Preserve the active frontend theme as the location for backend content templates; `admincoreui` is the backend shell.
 
-Escape output for its HTML context and keep Bootstrap expectations compatible with the selected InstantCMS template. Validate YAML layout schemes and the complete project before delivery.
+Escape output for its HTML context and keep Bootstrap expectations compatible with the selected InstantCMS template. Run `validate_layout_scheme`, create a reviewable patch, and audit the complete project before delivery. Before an InstantCMS upgrade, use `check_template_override_compatibility` with the old and new upstream file maps.

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -16,7 +16,12 @@ describe('MCP integration', () => {
       expect(listed.tools.some(tool => tool.name === 'plan_instantcms_upgrade')).toBe(true);
       expect(listed.tools.some(tool => tool.name === 'load_instantcms_project')).toBe(true);
       expect(listed.tools.some(tool => tool.name === 'create_project_patch')).toBe(true);
-      expect(listed.tools).toHaveLength(88);
+      expect(listed.tools.some(tool => tool.name === 'scaffold_complete_template')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'analyze_instantcms_template')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'check_template_override_compatibility')).toBe(
+        true
+      );
+      expect(listed.tools).toHaveLength(93);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
       expect(result.structuredContent).toMatchObject({ server_version: '1.2.0' });
     } finally {

--- a/src/__tests__/template-development.test.ts
+++ b/src/__tests__/template-development.test.ts
@@ -1,0 +1,101 @@
+import {
+  analyzeInstantCmsTemplate,
+  checkTemplateOverrideCompatibility,
+  scaffoldCompleteTemplate,
+  scaffoldTemplateOverride,
+  validateLayoutScheme,
+} from '../tools/template-development-tool.js';
+
+describe('template development workflows', () => {
+  test('scaffolds a complete template and layout scheme', () => {
+    const result = scaffoldCompleteTemplate({
+      name: 'studio_theme',
+      title: 'Studio Theme',
+      inherit: ['modern'],
+    });
+    expect(result.files['manifest.php']).toContain("'inherit' => ['modern']");
+    expect(result.files['manifest.php']).toContain("'has_options'                => false");
+    expect(result.files['main.tpl.php']).toContain("linkJS('js/main.js')");
+    expect(result.files['widgets/wrapper.tpl.php']).toContain('html($widget->title)');
+    expect(result.layout_scheme?.summary.positions).toEqual(
+      expect.arrayContaining(['header', 'content', 'right-top', 'footer'])
+    );
+  });
+
+  test('analyzes template structure, positions and overrides', () => {
+    const result = analyzeInstantCmsTemplate({
+      'manifest.php': '<?php return [];',
+      'main.tpl.php': "<?= $this->widgets('header') ?><?= $this->body() ?>",
+      'controllers/content/view.tpl.php': "<?= html($item['title']) ?>",
+    });
+    expect(result.is_valid).toBe(true);
+    expect(result.widget_positions).toContain('header');
+    expect(result.overrides).toContain('controllers/content/view.tpl.php');
+  });
+
+  test('discovers and analyzes a theme inside a complete project map', () => {
+    const result = analyzeInstantCmsTemplate({
+      'templates/studio_theme/manifest.php': '<?php return [];',
+      'templates/studio_theme/main.tpl.php': '<?= $this->body() ?>',
+    });
+    expect(result.theme).toBe('studio_theme');
+    expect(result.is_valid).toBe(true);
+  });
+
+  test('requires an explicit selection when a project contains multiple themes', () => {
+    const result = analyzeInstantCmsTemplate({
+      'templates/first/manifest.php': '<?php return [];',
+      'templates/second/manifest.php': '<?php return [];',
+    });
+    expect(result.is_valid).toBe(false);
+    expect(result.diagnostics.some(item => item.code === 'MULTIPLE_TEMPLATES_FOUND')).toBe(true);
+  });
+
+  test('creates frontend and backend overrides from an upstream path', () => {
+    const result = scaffoldTemplateOverride({
+      theme: 'studio_theme',
+      source_path: 'templates/modern/controllers/content/backend/items.tpl.php',
+      source_content: '<?php echo $this->renderGrid($grid);',
+    });
+    expect(result.target_path).toBe(
+      'templates/studio_theme/controllers/content/backend/items.tpl.php'
+    );
+    expect(result.files['controllers/content/backend/items.tpl.php']).toBeDefined();
+  });
+
+  test('validates layout YAML and reports duplicate positions', () => {
+    const result = validateLayoutScheme(
+      `layout:\n  rows:\n    - cols:\n        - position: sidebar\n        - position: sidebar\n`
+    );
+    expect(result.is_valid).toBe(true);
+    expect(result.diagnostics.some(item => item.code === 'DUPLICATE_LAYOUT_POSITION')).toBe(true);
+    expect(validateLayoutScheme('rows: []').is_valid).toBe(false);
+  });
+
+  test('marks an override when its upstream source changed or disappeared', () => {
+    const result = checkTemplateOverrideCompatibility(
+      {
+        'controllers/content/view.tpl.php': 'custom',
+        'controllers/users/index.tpl.php': 'custom users',
+      },
+      {
+        'templates/modern/controllers/content/view.tpl.php': 'old',
+        'templates/modern/controllers/users/index.tpl.php': 'old users',
+      },
+      { 'templates/modern/controllers/content/view.tpl.php': 'new' }
+    );
+    expect(result.requires_review).toBe(2);
+    expect(result.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'controllers/content/view.tpl.php',
+          status: 'upstream_changed',
+        }),
+        expect.objectContaining({
+          path: 'controllers/users/index.tpl.php',
+          status: 'missing_upstream',
+        }),
+      ])
+    );
+  });
+});

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -23,8 +23,12 @@ const workflows = {
   widget: ['list_widgets', 'scaffold_widget', 'validate_generated_artifacts'],
   template: [
     'get_template_structure',
-    'scaffold_template',
+    'scaffold_complete_template',
+    'analyze_instantcms_template',
+    'scaffold_template_override',
     'scaffold_layout_scheme',
+    'validate_layout_scheme',
+    'check_template_override_compatibility',
     'validate_generated_artifacts',
   ],
   audit: [
@@ -86,7 +90,7 @@ export function registerMetaTools(server: McpServer): void {
     async () =>
       successResult({
         server_version: '1.2.0',
-        tools_count: 88,
+        tools_count: 93,
         instantcms_profiles: instantCmsVersionProfiles,
         knowledge: {
           hooks: hooks.length,

--- a/src/registry/template-development-tools.ts
+++ b/src/registry/template-development-tools.ts
@@ -1,0 +1,87 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  analyzeInstantCmsTemplate,
+  checkTemplateOverrideCompatibility,
+  scaffoldCompleteTemplate,
+  scaffoldTemplateOverride,
+  validateLayoutScheme,
+} from '../tools/template-development-tool.js';
+import { successResult } from '../utils/mcp-result.js';
+
+const templateFilesSchema = z
+  .record(z.string(), z.string())
+  .refine(files => Object.keys(files).length <= 3000);
+
+export function registerTemplateDevelopmentTools(server: McpServer): void {
+  server.tool(
+    'scaffold_complete_template',
+    'Создаёт полный каркас frontend-шаблона InstantCMS и импортируемую layout-схему',
+    {
+      name: z.string().regex(/^[a-z][a-z0-9_]{1,63}$/),
+      title: z.string().trim().min(1).max(200),
+      author: z.string().trim().max(200).optional(),
+      inherit: z
+        .array(z.string().regex(/^[a-z][a-z0-9_]{1,63}$/))
+        .max(10)
+        .optional(),
+      with_layout_scheme: z.boolean().optional().default(true),
+    },
+    async options => successResult(scaffoldCompleteTemplate(options))
+  );
+  server.tool(
+    'analyze_instantcms_template',
+    'Анализирует структуру, overrides, widget positions, layout-файлы и риски шаблона',
+    {
+      files: templateFilesSchema,
+      theme: z
+        .string()
+        .regex(/^[a-z][a-z0-9_]{1,63}$/)
+        .optional(),
+    },
+    async ({ files, theme }) => successResult(analyzeInstantCmsTemplate(files, theme))
+  );
+  server.tool(
+    'scaffold_template_override',
+    'Создаёт точную копию upstream template-файла в правильном каталоге override темы',
+    {
+      theme: z.string().regex(/^[a-z][a-z0-9_]{1,63}$/),
+      source_path: z.string().min(1).max(500),
+      source_content: z.string().max(2 * 1024 * 1024),
+      controller: z
+        .string()
+        .regex(/^[a-z][a-z0-9_]{1,63}$/)
+        .optional(),
+      action: z
+        .string()
+        .regex(/^[a-z][a-z0-9_]{0,63}$/)
+        .optional(),
+      backend: z.boolean().optional(),
+    },
+    async options => successResult(scaffoldTemplateOverride(options))
+  );
+  server.tool(
+    'validate_layout_scheme',
+    'Проверяет YAML-синтаксис, layout root и widget positions схемы InstantCMS',
+    {
+      yaml: z
+        .string()
+        .min(1)
+        .max(2 * 1024 * 1024),
+    },
+    async ({ yaml }) => successResult(validateLayoutScheme(yaml))
+  );
+  server.tool(
+    'check_template_override_compatibility',
+    'Сравнивает overrides темы с upstream template-файлами до и после обновления InstantCMS',
+    {
+      theme_files: templateFilesSchema,
+      upstream_before: templateFilesSchema,
+      upstream_after: templateFilesSchema,
+    },
+    async ({ theme_files, upstream_before, upstream_after }) =>
+      successResult(
+        checkTemplateOverrideCompatibility(theme_files, upstream_before, upstream_after)
+      )
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { registerLanguageTools } from './registry/language-tools.js';
 import { registerExtensionTools } from './registry/extension-tools.js';
 import { registerResources } from './registry/resources.js';
 import { registerProjectTools } from './registry/project-tools.js';
+import { registerTemplateDevelopmentTools } from './registry/template-development-tools.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -26,6 +27,7 @@ export function createServer(): McpServer {
   registerExtensionTools(server);
   registerResources(server);
   registerProjectTools(server);
+  registerTemplateDevelopmentTools(server);
 
   return server;
 }

--- a/src/tools/template-development-tool.ts
+++ b/src/tools/template-development-tool.ts
@@ -1,0 +1,326 @@
+import { parse } from 'yaml';
+import { scaffoldTemplate } from './scaffold-tool.js';
+import { scaffoldLayoutScheme, type RowDef } from './layout-tool.js';
+
+const safeNamePattern = /^[a-z][a-z0-9_]{1,63}$/;
+
+function normalizeFiles(files: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(files).map(([path, content]) => [
+      path.replace(/\\/g, '/').replace(/^\.\//, ''),
+      content,
+    ])
+  );
+}
+
+function assertSafeName(value: string, label: string): void {
+  if (!safeNamePattern.test(value)) throw new Error(`${label} must match ${safeNamePattern}`);
+}
+
+export function scaffoldCompleteTemplate(options: {
+  name: string;
+  title: string;
+  author?: string;
+  inherit?: string[];
+  with_layout_scheme?: boolean;
+}) {
+  assertSafeName(options.name, 'Template name');
+  const base = scaffoldTemplate({
+    name: options.name,
+    title: options.title,
+    author: options.author,
+  }) as {
+    files: Record<string, string>;
+    [key: string]: unknown;
+  };
+  const files = { ...base.files };
+  files['manifest.php'] = files['manifest.php'].replace(
+    "'has_options'                => true",
+    "'has_options'                => false"
+  );
+  const inherits = (options.inherit ?? []).filter(Boolean);
+  if (inherits.length) {
+    for (const item of inherits) assertSafeName(item, 'Inherited template name');
+    files['manifest.php'] = files['manifest.php'].replace(
+      'return [',
+      `return [\n    'inherit' => [${inherits.map(item => `'${item}'`).join(', ')}],`
+    );
+  }
+  files['js/main.js'] =
+    `(() => {\n    'use strict';\n    document.documentElement.classList.add('js');\n})();\n`;
+  files['widgets/wrapper.tpl.php'] =
+    `<section class="widget<?= !empty($widget->css_class) ? ' ' . html($widget->css_class) : '' ?>">\n    <?php if (!empty($widget->title)): ?>\n        <h2 class="widget-title"><?= html($widget->title) ?></h2>\n    <?php endif ?>\n    <div class="widget-body"><?= $widget->body ?></div>\n</section>\n`;
+  files['main.tpl.php'] = files['main.tpl.php'].replace(
+    "<?= $this->linkCSS('css/main.css') ?>",
+    "<?= $this->linkCSS('css/main.css') ?>\n    <?= $this->linkJS('js/main.js') ?>"
+  );
+
+  const layout =
+    options.with_layout_scheme === false
+      ? null
+      : scaffoldLayoutScheme({
+          template: options.name,
+          rows: [
+            {
+              title: 'Header',
+              outer_tag: 'header',
+              cols: [{ title: 'Header', position: 'header', col_class: 'col-12' }],
+            },
+            {
+              title: 'Content',
+              tag: 'main',
+              cols: [
+                { title: 'Main', position: 'content', col_class: 'col-lg-8' },
+                { title: 'Sidebar', position: 'right-top', col_class: 'col-lg-4' },
+              ],
+            },
+            {
+              title: 'Footer',
+              outer_tag: 'footer',
+              cols: [{ title: 'Footer', position: 'footer', col_class: 'col-12' }],
+            },
+          ],
+        });
+
+  return {
+    ...base,
+    files,
+    layout_scheme: layout,
+    checklist: [
+      `Install files into /templates/${options.name}/.`,
+      'Import layout_scheme.yaml through the template layout administration UI if required.',
+      'Run analyze_instantcms_template and validate_layout_scheme before packaging.',
+    ],
+  };
+}
+
+export function analyzeInstantCmsTemplate(filesInput: Record<string, string>, theme?: string) {
+  const normalized = normalizeFiles(filesInput);
+  if (theme) assertSafeName(theme, 'Theme name');
+  const discovered = [
+    ...new Set(
+      Object.keys(normalized).flatMap(
+        path => path.match(/(?:^|\/)templates\/([^/]+)\/manifest\.php$/)?.[1] ?? []
+      )
+    ),
+  ];
+  const selectedTheme = theme ?? (discovered.length === 1 ? discovered[0] : null);
+  const prefix = selectedTheme ? `templates/${selectedTheme}/` : '';
+  const files = prefix
+    ? Object.fromEntries(
+        Object.entries(normalized)
+          .filter(([path]) => path.startsWith(prefix))
+          .map(([path, content]) => [path.slice(prefix.length), content])
+      )
+    : normalized;
+  const paths = Object.keys(files);
+  const diagnostics: Array<{
+    code: string;
+    severity: 'error' | 'warning';
+    path: string;
+    message: string;
+  }> = [];
+  if (!theme && discovered.length > 1) {
+    diagnostics.push({
+      code: 'MULTIPLE_TEMPLATES_FOUND',
+      severity: 'error',
+      path: 'templates/',
+      message: `Multiple templates found (${discovered.join(', ')}); select one with the theme parameter.`,
+    });
+  }
+  for (const required of ['manifest.php', 'main.tpl.php']) {
+    if (!(required in files))
+      diagnostics.push({
+        code: 'MISSING_TEMPLATE_FILE',
+        severity: 'error',
+        path: required,
+        message: `Required template file ${required} is missing.`,
+      });
+  }
+  if (files['manifest.json'])
+    diagnostics.push({
+      code: 'INVALID_TEMPLATE_MANIFEST',
+      severity: 'error',
+      path: 'manifest.json',
+      message: 'InstantCMS templates use manifest.php, not manifest.json.',
+    });
+  if (files['main.tpl.php'] && !files['main.tpl.php'].includes('$this->body()'))
+    diagnostics.push({
+      code: 'MISSING_TEMPLATE_BODY',
+      severity: 'error',
+      path: 'main.tpl.php',
+      message: 'Main template does not render $this->body().',
+    });
+  const phpTemplates = paths.filter(path => path.endsWith('.tpl.php'));
+  for (const path of phpTemplates) {
+    const content = files[path];
+    if (/echo\s+\$(?!this\b)[a-z_][a-z0-9_]*(?:\[[^\]]+\])?\s*;/i.test(content))
+      diagnostics.push({
+        code: 'POSSIBLE_UNESCAPED_TEMPLATE_OUTPUT',
+        severity: 'warning',
+        path,
+        message: 'Variable output may require context-aware escaping.',
+      });
+  }
+  const positions = [
+    ...new Set(
+      Object.values(files).flatMap(content =>
+        [...content.matchAll(/(?:widgets|hasWidgetsOn)\(\s*['"]([^'"]+)['"]/g)].map(
+          match => match[1]
+        )
+      )
+    ),
+  ].sort();
+  const overrides = paths.filter(path =>
+    /^controllers\/[^/]+\/(?:backend\/)?[^/]+\.tpl\.php$/.test(path)
+  );
+  const layoutFiles = paths.filter(path => /(?:^|\/)layout[^/]*\.(?:ya?ml)$/i.test(path));
+  return {
+    theme: selectedTheme,
+    discovered_themes: discovered,
+    is_valid: !diagnostics.some(item => item.severity === 'error'),
+    summary: {
+      files: paths.length,
+      php_templates: phpTemplates.length,
+      overrides: overrides.length,
+      positions: positions.length,
+      layouts: layoutFiles.length,
+    },
+    widget_positions: positions,
+    overrides,
+    layout_files: layoutFiles,
+    diagnostics,
+  };
+}
+
+export function scaffoldTemplateOverride(options: {
+  theme: string;
+  source_path: string;
+  source_content: string;
+  controller?: string;
+  action?: string;
+  backend?: boolean;
+}) {
+  assertSafeName(options.theme, 'Theme name');
+  const source = options.source_path.replace(/\\/g, '/').replace(/^\.\//, '');
+  const match = source.match(
+    /(?:^|\/)(?:templates\/[^/]+\/)?controllers\/([^/]+)\/(backend\/)?([^/]+\.tpl\.php)$/
+  );
+  const controller = options.controller ?? match?.[1];
+  const actionFile = options.action ? `${options.action}.tpl.php` : match?.[3];
+  const backend = options.backend ?? Boolean(match?.[2]);
+  if (!controller || !actionFile)
+    throw new Error('Controller and action could not be derived from source_path');
+  assertSafeName(controller, 'Controller name');
+  if (!/^[a-z][a-z0-9_]{0,63}\.tpl\.php$/.test(actionFile))
+    throw new Error('Invalid template action');
+  const relative = `controllers/${controller}/${backend ? 'backend/' : ''}${actionFile}`;
+  return {
+    theme: options.theme,
+    source_path: source,
+    target_path: `templates/${options.theme}/${relative}`,
+    files: { [relative]: options.source_content },
+    review_notes: [
+      'Keep the override as small as possible.',
+      'Record the upstream InstantCMS version or commit used as the source.',
+      'Recheck this override when the upstream source template changes.',
+    ],
+  };
+}
+
+function collectLayoutPositions(value: unknown, positions: string[]): void {
+  if (Array.isArray(value)) return value.forEach(item => collectLayoutPositions(item, positions));
+  if (!value || typeof value !== 'object') return;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (key === 'position' && typeof child === 'string') positions.push(child);
+    collectLayoutPositions(child, positions);
+  }
+}
+
+export function validateLayoutScheme(yaml: string) {
+  const diagnostics: Array<{ code: string; severity: 'error' | 'warning'; message: string }> = [];
+  let document: unknown;
+  try {
+    document = parse(yaml);
+  } catch (error) {
+    return {
+      is_valid: false,
+      positions: [],
+      diagnostics: [
+        {
+          code: 'INVALID_LAYOUT_YAML',
+          severity: 'error' as const,
+          message: error instanceof Error ? error.message : 'Invalid YAML',
+        },
+      ],
+    };
+  }
+  if (!document || typeof document !== 'object' || !('layout' in document))
+    diagnostics.push({
+      code: 'MISSING_LAYOUT_ROOT',
+      severity: 'error',
+      message: 'Layout YAML must contain a layout root.',
+    });
+  const positions: string[] = [];
+  collectLayoutPositions(document, positions);
+  const duplicates = [
+    ...new Set(positions.filter((item, index) => positions.indexOf(item) !== index)),
+  ];
+  if (duplicates.length)
+    diagnostics.push({
+      code: 'DUPLICATE_LAYOUT_POSITION',
+      severity: 'warning',
+      message: `Duplicate positions: ${duplicates.join(', ')}`,
+    });
+  if (!positions.length)
+    diagnostics.push({
+      code: 'MISSING_LAYOUT_POSITIONS',
+      severity: 'warning',
+      message: 'No widget positions were found.',
+    });
+  return {
+    is_valid: !diagnostics.some(item => item.severity === 'error'),
+    positions: [...new Set(positions)],
+    diagnostics,
+  };
+}
+
+export function checkTemplateOverrideCompatibility(
+  themeFilesInput: Record<string, string>,
+  upstreamBeforeInput: Record<string, string>,
+  upstreamAfterInput: Record<string, string>
+) {
+  const themeFiles = normalizeFiles(themeFilesInput);
+  const before = normalizeFiles(upstreamBeforeInput);
+  const after = normalizeFiles(upstreamAfterInput);
+  const overrides = Object.keys(themeFiles).filter(path =>
+    /^controllers\/[^/]+\/(?:backend\/)?[^/]+\.tpl\.php$/.test(path)
+  );
+  const findSource = (files: Record<string, string>, override: string) =>
+    Object.keys(files).find(path => path === override || path.endsWith(`/${override}`));
+  const results = overrides.map(path => {
+    const beforePath = findSource(before, path);
+    const afterPath = findSource(after, path);
+    const status = !afterPath
+      ? 'missing_upstream'
+      : !beforePath
+        ? 'untracked'
+        : before[beforePath] !== after[afterPath]
+          ? 'upstream_changed'
+          : 'compatible';
+    return {
+      path,
+      status,
+      upstream_before: beforePath ?? null,
+      upstream_after: afterPath ?? null,
+      requires_review: status !== 'compatible',
+    };
+  });
+  return {
+    overrides_checked: overrides.length,
+    requires_review: results.filter(item => item.requires_review).length,
+    results,
+  };
+}
+
+export type { RowDef };


### PR DESCRIPTION
## Summary
- add complete InstantCMS template scaffolding with layout scheme output
- analyze standalone themes or themes inside complete project maps
- create source-preserving frontend/backend template overrides
- validate layout YAML and widget positions
- compare overrides against upstream templates across InstantCMS upgrades
- update template workflow, skill, MCP metadata, architecture, changelog, and README

## Validation
- npm run check
- npm run test:integration
- npm run build
- npm run lint
- npm audit --audit-level=high