### PR TITLE
Add template productivity suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@
 - `src/server.ts` is the composition root: it creates the MCP server and invokes domain registrars.
 - `src/registry/` owns transport-facing Zod schemas and tool/resource registration, split into generators, knowledge, database, source analysis, language, extensions, metadata, and resources.
 - `src/registry/project-tools.ts` exposes bounded local/GitHub project loading, read-only analysis, reviewable repair planning, unified patch generation, safe file-map transformations, and version upgrade planning.
-- `src/registry/template-development-tools.ts` owns complete theme scaffolding, existing-theme analysis, source-preserving overrides, layout validation, and upstream compatibility checks.
+- `src/registry/template-development-tools.ts` owns complete theme scaffolding, existing-theme analysis, source provenance, source-preserving and three-way override updates, frontend/PHP quality, design tokens, widget positions, layout validation, visual E2E scaffolding, and upstream compatibility checks.
 - `src/utils/mcp-result.ts` задаёт единый `content + structuredContent + isError` контракт.
 - `src/utils/pagination.ts` реализует cursor pagination для больших справочников.
 - `src/tools/` contains deterministic domain operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add bounded project loading from local directories and public GitHub repositories.
 - Generate unified Git patches directly and include them in safe project repair results.
 - Add complete template scaffolding, existing-theme analysis, source-preserving overrides, layout validation, and upstream override compatibility checks.
+- Add safe three-way override updates, frontend/accessibility and PHP quality tooling, upstream template provenance, design-token extraction, widget-position checks, and generated Docker/Playwright visual tests.
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 - диагностические коды для автоматического исправления;
 - экранирование пользовательских данных для XML, INI, PHP и YAML;
 - AI-инструкции и skills без дублирования базы знаний.
-- 93 MCP-инструмента и четыре встроенных MCP resource;
+- 100 MCP-инструментов и четыре встроенных MCP resource;
 - воспроизводимая генерация runtime-справочников из зафиксированного commit InstantCMS;
 - автоматическая еженедельная проверка обновлений и Pull Request с изменившимися данными;
 - CI на Node.js 18, 20, 22 и 24 с отдельной проверкой официальных исходников InstantCMS.
@@ -61,11 +61,11 @@ npm run inspector
 npm run check
 ```
 
-`npm run check` выполняет проверку provenance/generated metadata, TypeScript, 245 unit-тестов и конфигураций AI-клиентов. Интеграционный MCP smoke-test запускается отдельно командой `npm run test:integration`.
+`npm run check` выполняет проверку provenance/generated metadata, TypeScript, unit-тестов и конфигураций AI-клиентов. Интеграционный MCP smoke-test запускается отдельно командой `npm run test:integration`.
 
 ## Основные MCP-инструменты
 
-Сервер регистрирует 93 инструмента. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, углублённую разработку шаблонов, загрузку и аудит существующих проектов, patch generation и планирование обновлений.
+Сервер регистрирует 100 инструментов. Ниже перечислены базовые точки входа; расширенные инструменты охватывают CRUD, БД, миграции, формы, гриды, API, email, cron, permissions, SEO, импорт/экспорт, cache, webhooks, OAuth, widgets, углублённую разработку и визуальное тестирование шаблонов, загрузку и аудит существующих проектов, patch generation и планирование обновлений.
 
 | Инструмент                                      | Назначение                                      |
 | ----------------------------------------------- | ----------------------------------------------- |
@@ -101,6 +101,13 @@ npm run check
 | `scaffold_template_override`                    | Override из upstream template-файла             |
 | `validate_layout_scheme`                        | Проверка YAML layout-схемы                      |
 | `check_template_override_compatibility`         | Проверка overrides при обновлении InstantCMS    |
+| `merge_template_overrides`                      | Безопасный трёхсторонний merge overrides        |
+| `audit_template_frontend`                       | HTML, accessibility, escaping и CSS-аудит       |
+| `extract_template_design_tokens`                | Извлечение цветов, spacing и CSS tokens         |
+| `audit_template_widget_positions`               | Сверка PHP-позиций с layout YAML                |
+| `scaffold_template_e2e_environment`             | Docker и Playwright visual regression           |
+| `index_upstream_template_sources`               | SHA-256 provenance upstream-шаблонов            |
+| `scaffold_template_php_quality`                 | PHPStan, PHPCS и PHPCompatibility               |
 
 Сервер также публикует MCP resources со всеми хуками, компонентами, типами дополнений и quickstart.
 
@@ -116,7 +123,7 @@ npm run check
 | `language-tools`             |          3 | языковые ключи, language files и migration scaffold                              |
 | `extension-tools`            |         17 | WYSIWYG, permissions, filters, SEO, import/export, cache, webhooks, OAuth и темы |
 | `project-tools`              |          7 | загрузка, аудит, объяснение, план, безопасный repair, patch и upgrade planner    |
-| `template-development-tools` |          5 | полный scaffold, анализ, overrides, layout validation и upgrade compatibility    |
+| `template-development-tools` |         12 | scaffold, merge, frontend/PHP quality, provenance, tokens, layouts и visual E2E  |
 
 Полные имена, входные Zod-схемы и описания доступны клиенту через стандартный MCP `tools/list`. Для начала неизвестной задачи используйте `diagnose_request`, `find_tool` или `get_workflow`.
 
@@ -204,7 +211,9 @@ Skills разделены по workflow:
 
 Локальный loader рекурсивно читает только текстовые файлы, не следует по symbolic links и пропускает `.git`, `node_modules`, `vendor`, сборочные каталоги и бинарные данные. GitHub loader принимает `owner/repository` или URL публичного репозитория, точный `ref` и необязательный `subpath`. Для обоих источников действуют ограничения количества файлов, размера одного файла и общего объёма.
 
-Для разработки темы используйте цикл `load_instantcms_project → analyze_instantcms_template → scaffold_complete_template/scaffold_template_override → validate_layout_scheme → create_project_patch → audit_instantcms_project`. Перед обновлением InstantCMS передайте старую и новую upstream-карты шаблонов в `check_template_override_compatibility`: инструмент отделит совместимые overrides от изменённых или удалённых upstream-файлов, требующих ручной проверки.
+Для разработки темы используйте цикл `load_instantcms_project → analyze_instantcms_template → scaffold_complete_template/scaffold_template_override → audit_template_widget_positions → validate_layout_scheme → audit_template_frontend → create_project_patch → audit_instantcms_project`. Design tokens можно получить через `extract_template_design_tokens`, PHP quality-конфигурацию — через `scaffold_template_php_quality`, а Docker/Playwright окружение — через `scaffold_template_e2e_environment`.
+
+Перед обновлением InstantCMS зафиксируйте карту исходников через `index_upstream_template_sources`, передайте старую и новую upstream-карты в `check_template_override_compatibility`, затем вызовите `merge_template_overrides`. Неизменённые overrides обновляются автоматически; одно однозначное upstream-изменение переносится в кастомный файл; неоднозначные изменения остаются конфликтами и не модифицируются. Результат всегда содержит reviewable Git patch.
 
 Большие справочники не копируются в skills. Агент получает факты через MCP tools/resources и `knowledge/`, а skill определяет порядок работы и критерии готовности.
 

--- a/skills/instantcms-theme/SKILL.md
+++ b/skills/instantcms-theme/SKILL.md
@@ -5,6 +5,8 @@ description: Build or modify InstantCMS themes, template overrides, layout schem
 
 # InstantCMS theme
 
-Start with `load_instantcms_project` and `analyze_instantcms_template`; use `get_template_structure` for framework rules. Create new themes with `scaffold_complete_template` and copy an exact upstream file with `scaffold_template_override` before making the smallest required override. Preserve the active frontend theme as the location for backend content templates; `admincoreui` is the backend shell.
+Start with `load_instantcms_project` and `analyze_instantcms_template`; use `get_template_structure` for framework rules. Create themes with `scaffold_complete_template` and copy an exact upstream file with `scaffold_template_override` before making the smallest required override. Preserve the active frontend theme as the location for backend content templates; `admincoreui` is the backend shell.
 
-Escape output for its HTML context and keep Bootstrap expectations compatible with the selected InstantCMS template. Run `validate_layout_scheme`, create a reviewable patch, and audit the complete project before delivery. Before an InstantCMS upgrade, use `check_template_override_compatibility` with the old and new upstream file maps.
+Before delivery, reconcile PHP and YAML positions with `audit_template_widget_positions`, validate layouts, and run frontend plus relevant PHP quality checks. Use extracted design tokens as a migration aid, not as permission to rewrite established styling. Generate visual tests when an installed InstantCMS environment is available, then review desktop/mobile screenshots and browser errors.
+
+For upgrades, index the exact upstream ref and compare old and new maps first. Let `merge_template_overrides` modify only clean cases; review every conflict and the generated patch before writing files. Finish with project audit and the relevant visual regression tests.

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -21,7 +21,14 @@ describe('MCP integration', () => {
       expect(listed.tools.some(tool => tool.name === 'check_template_override_compatibility')).toBe(
         true
       );
-      expect(listed.tools).toHaveLength(93);
+      expect(listed.tools.some(tool => tool.name === 'merge_template_overrides')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'audit_template_frontend')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'scaffold_template_e2e_environment')).toBe(
+        true
+      );
+      expect(listed.tools.some(tool => tool.name === 'index_upstream_template_sources')).toBe(true);
+      expect(listed.tools.some(tool => tool.name === 'scaffold_template_php_quality')).toBe(true);
+      expect(listed.tools).toHaveLength(100);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
       expect(result.structuredContent).toMatchObject({ server_version: '1.2.0' });
     } finally {

--- a/src/__tests__/template-productivity.test.ts
+++ b/src/__tests__/template-productivity.test.ts
@@ -1,0 +1,131 @@
+import {
+  auditTemplateFrontend,
+  auditTemplateWidgetPositions,
+  extractTemplateDesignTokens,
+  mergeTemplateOverrides,
+  scaffoldTemplateE2eEnvironment,
+  indexUpstreamTemplateSources,
+  scaffoldTemplatePhpQuality,
+} from '../tools/template-productivity-tool.js';
+import { spawnSync } from 'node:child_process';
+import { parse } from 'yaml';
+
+describe('template productivity workflows', () => {
+  test('updates untouched overrides and returns a patch', () => {
+    const result = mergeTemplateOverrides(
+      { 'controllers/content/view.tpl.php': 'old upstream' },
+      { 'templates/modern/controllers/content/view.tpl.php': 'old upstream' },
+      { 'templates/modern/controllers/content/view.tpl.php': 'new upstream' }
+    );
+    expect(result.files['controllers/content/view.tpl.php']).toBe('new upstream');
+    expect(result.summary.auto_merged).toBe(1);
+    expect(result.patch.patch).toContain('+new upstream');
+  });
+
+  test('preserves customized overrides and reports a conflict', () => {
+    const result = mergeTemplateOverrides(
+      { 'controllers/content/view.tpl.php': 'custom theme' },
+      { 'controllers/content/view.tpl.php': 'old upstream' },
+      { 'controllers/content/view.tpl.php': 'new upstream' }
+    );
+    expect(result.files['controllers/content/view.tpl.php']).toBe('custom theme');
+    expect(result.summary.conflicts).toBe(1);
+    expect(result.patch.is_empty).toBe(true);
+  });
+
+  test('applies one unambiguous upstream delta to a customized override', () => {
+    const result = mergeTemplateOverrides(
+      { 'controllers/content/view.tpl.php': 'custom header\nold block\ncustom footer' },
+      { 'controllers/content/view.tpl.php': 'base header\nold block\nbase footer' },
+      { 'controllers/content/view.tpl.php': 'base header\nnew block\nbase footer' }
+    );
+    expect(result.files['controllers/content/view.tpl.php']).toBe(
+      'custom header\nnew block\ncustom footer'
+    );
+    expect(result.results[0].status).toBe('upstream_delta_applied');
+  });
+
+  test('reports accessibility and HTML quality issues', () => {
+    const result = auditTemplateFrontend({
+      'main.tpl.php':
+        '<html><h1>Title</h1><h3>Section</h3><img src="a.jpg"><a target="_blank">x</a><div id="same"></div><div id="same"></div></html>',
+    });
+    expect(result.is_valid).toBe(false);
+    expect(result.diagnostics.map(item => item.code)).toEqual(
+      expect.arrayContaining([
+        'IMAGE_MISSING_ALT',
+        'UNSAFE_BLANK_TARGET',
+        'DUPLICATE_HTML_ID',
+        'SKIPPED_HEADING_LEVEL',
+        'HTML_LANG_MISSING',
+      ])
+    );
+  });
+
+  test('extracts repeated design values and existing custom properties', () => {
+    const result = extractTemplateDesignTokens({
+      'css/main.css':
+        ':root{--brand:#123456}.a{color:#123456;padding:1rem}.b{color:#123456;gap:1rem}',
+    });
+    expect(result.existing_custom_properties['--brand']).toBe('#123456');
+    expect(result.colors[0]).toEqual({ value: '#123456', uses: 3 });
+    expect(result.suggested_tokens_css).toContain('--space-1: 1rem');
+  });
+
+  test('compares rendered, guarded and layout widget positions', () => {
+    const result = auditTemplateWidgetPositions({
+      'main.tpl.php':
+        "<?= $this->widgets('header') ?><?= $this->widgets('sidebar') ?><?= $this->hasWidgetsOn('sidebar') ?>",
+      'layout.yaml':
+        'layout:\n  rows:\n    - cols:\n        - position: header\n        - position: footer\n',
+    });
+    expect(result.layout_not_rendered).toContain('footer');
+    expect(result.rendered_not_in_layout).toContain('sidebar');
+    expect(result.unguarded_positions).toContain('header');
+  });
+
+  test('scaffolds reproducible Docker and Playwright visual tests', () => {
+    const result = scaffoldTemplateE2eEnvironment({ theme: 'studio_theme' });
+    expect(result.files['template-e2e/compose.yaml']).toContain('mcr.microsoft.com/playwright');
+    expect(result.files['template-e2e/tests/template.spec.mjs']).toContain('toHaveScreenshot');
+    expect(result.files['template-e2e/php/Dockerfile']).toContain('docker-php-ext-install');
+    expect(parse(result.files['template-e2e/compose.yaml']).services.visual.image).toContain(
+      'playwright'
+    );
+    for (const path of [
+      'template-e2e/playwright.config.mjs',
+      'template-e2e/tests/template.spec.mjs',
+    ] as const) {
+      const syntax = spawnSync(process.execPath, ['--input-type=module', '--check', '-'], {
+        input: result.files[path],
+        encoding: 'utf8',
+      });
+      expect(syntax.status).toBe(0);
+    }
+  });
+
+  test('indexes upstream templates with reproducible provenance', () => {
+    const result = indexUpstreamTemplateSources(
+      { 'templates/modern/controllers/content/view.tpl.php': '<?php echo 1;' },
+      { repository: 'instantsoft/icms2', ref: 'abc123' }
+    );
+    expect(result.files_indexed).toBe(1);
+    expect(result.templates[0]).toEqual(
+      expect.objectContaining({
+        controller: 'content',
+        action: 'view',
+        sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      })
+    );
+    expect(result.templates[0].source_url).toContain('/blob/abc123/');
+  });
+
+  test('scaffolds PHP static-analysis configuration', () => {
+    const result = scaffoldTemplatePhpQuality({ theme: 'studio_theme', php_min: '7.2' });
+    expect(JSON.parse(result.files['composer.quality.json'])['require-dev']).toHaveProperty(
+      'phpstan/phpstan'
+    );
+    expect(result.files['phpcs.xml']).toContain('PHPCompatibility');
+    expect(result.files['phpstan.neon']).toContain('templates/studio_theme');
+  });
+});

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -29,6 +29,13 @@ const workflows = {
     'scaffold_layout_scheme',
     'validate_layout_scheme',
     'check_template_override_compatibility',
+    'merge_template_overrides',
+    'audit_template_frontend',
+    'extract_template_design_tokens',
+    'audit_template_widget_positions',
+    'scaffold_template_e2e_environment',
+    'index_upstream_template_sources',
+    'scaffold_template_php_quality',
     'validate_generated_artifacts',
   ],
   audit: [
@@ -90,7 +97,7 @@ export function registerMetaTools(server: McpServer): void {
     async () =>
       successResult({
         server_version: '1.2.0',
-        tools_count: 93,
+        tools_count: 100,
         instantcms_profiles: instantCmsVersionProfiles,
         knowledge: {
           hooks: hooks.length,

--- a/src/registry/template-development-tools.ts
+++ b/src/registry/template-development-tools.ts
@@ -8,12 +8,83 @@ import {
   validateLayoutScheme,
 } from '../tools/template-development-tool.js';
 import { successResult } from '../utils/mcp-result.js';
+import {
+  auditTemplateFrontend,
+  auditTemplateWidgetPositions,
+  extractTemplateDesignTokens,
+  mergeTemplateOverrides,
+  scaffoldTemplateE2eEnvironment,
+  indexUpstreamTemplateSources,
+  scaffoldTemplatePhpQuality,
+} from '../tools/template-productivity-tool.js';
 
 const templateFilesSchema = z
   .record(z.string(), z.string())
   .refine(files => Object.keys(files).length <= 3000);
 
 export function registerTemplateDevelopmentTools(server: McpServer): void {
+  server.tool(
+    'merge_template_overrides',
+    'Безопасно переносит upstream-изменения в неизменённые overrides и возвращает Git patch',
+    {
+      theme_files: templateFilesSchema,
+      upstream_before: templateFilesSchema,
+      upstream_after: templateFilesSchema,
+    },
+    async ({ theme_files, upstream_before, upstream_after }) =>
+      successResult(mergeTemplateOverrides(theme_files, upstream_before, upstream_after))
+  );
+  server.tool(
+    'audit_template_frontend',
+    'Проверяет HTML, accessibility, escaping и качество CSS файлов шаблона',
+    { files: templateFilesSchema },
+    async ({ files }) => successResult(auditTemplateFrontend(files))
+  );
+  server.tool(
+    'extract_template_design_tokens',
+    'Извлекает CSS custom properties, цвета и spacing и предлагает design tokens',
+    { files: templateFilesSchema },
+    async ({ files }) => successResult(extractTemplateDesignTokens(files))
+  );
+  server.tool(
+    'audit_template_widget_positions',
+    'Сопоставляет позиции виджетов в PHP-шаблонах и YAML layout-схемах',
+    { files: templateFilesSchema },
+    async ({ files }) => successResult(auditTemplateWidgetPositions(files))
+  );
+  server.tool(
+    'scaffold_template_e2e_environment',
+    'Генерирует Docker Compose и Playwright visual regression окружение для темы',
+    {
+      theme: z.string().regex(/^[a-z][a-z0-9_]{1,63}$/),
+      base_url: z.string().url().optional(),
+    },
+    async options => successResult(scaffoldTemplateE2eEnvironment(options))
+  );
+  server.tool(
+    'index_upstream_template_sources',
+    'Индексирует upstream template-файлы с SHA-256 и ссылками на исходный commit',
+    {
+      files: templateFilesSchema,
+      repository: z.string().regex(/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/),
+      ref: z.string().regex(/^[a-zA-Z0-9._/-]+$/),
+    },
+    async ({ files, repository, ref }) =>
+      successResult(indexUpstreamTemplateSources(files, { repository, ref }))
+  );
+  server.tool(
+    'scaffold_template_php_quality',
+    'Генерирует PHPStan, PHPCS и PHPCompatibility конфигурацию для шаблона',
+    {
+      theme: z.string().regex(/^[a-z][a-z0-9_]{1,63}$/),
+      php_min: z
+        .string()
+        .regex(/^\d+\.\d+$/)
+        .optional()
+        .default('7.2'),
+    },
+    async options => successResult(scaffoldTemplatePhpQuality(options))
+  );
   server.tool(
     'scaffold_complete_template',
     'Создаёт полный каркас frontend-шаблона InstantCMS и импортируемую layout-схему',

--- a/src/tools/template-productivity-tool.ts
+++ b/src/tools/template-productivity-tool.ts
@@ -1,0 +1,355 @@
+import { parse } from 'yaml';
+import { createProjectPatch } from './project-patch-tool.js';
+import { createHash } from 'node:crypto';
+
+function normalizeFiles(files: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(files).map(([path, content]) => [
+      path.replace(/\\/g, '/').replace(/^\.\//, ''),
+      content,
+    ])
+  );
+}
+
+function overridePaths(files: Record<string, string>): string[] {
+  return Object.keys(files).filter(path =>
+    /^controllers\/[^/]+\/(?:backend\/)?[^/]+\.tpl\.php$/.test(path)
+  );
+}
+
+function findSource(files: Record<string, string>, override: string): string | undefined {
+  return Object.keys(files).find(path => path === override || path.endsWith(`/${override}`));
+}
+
+function applySingleUpstreamDelta(base: string, current: string, incoming: string): string | null {
+  let prefix = 0;
+  while (prefix < base.length && prefix < incoming.length && base[prefix] === incoming[prefix])
+    prefix += 1;
+  let suffix = 0;
+  while (
+    suffix < base.length - prefix &&
+    suffix < incoming.length - prefix &&
+    base[base.length - 1 - suffix] === incoming[incoming.length - 1 - suffix]
+  )
+    suffix += 1;
+  const removed = base.slice(prefix, base.length - suffix);
+  const added = incoming.slice(prefix, incoming.length - suffix);
+  if (!removed) return null;
+  const first = current.indexOf(removed);
+  if (first < 0 || current.indexOf(removed, first + removed.length) >= 0) return null;
+  return `${current.slice(0, first)}${added}${current.slice(first + removed.length)}`;
+}
+
+export function mergeTemplateOverrides(
+  themeFilesInput: Record<string, string>,
+  upstreamBeforeInput: Record<string, string>,
+  upstreamAfterInput: Record<string, string>
+) {
+  const themeFiles = normalizeFiles(themeFilesInput);
+  const upstreamBefore = normalizeFiles(upstreamBeforeInput);
+  const upstreamAfter = normalizeFiles(upstreamAfterInput);
+  const mergedFiles = { ...themeFiles };
+  const results = overridePaths(themeFiles).map(path => {
+    const beforePath = findSource(upstreamBefore, path);
+    const afterPath = findSource(upstreamAfter, path);
+    if (!beforePath || !afterPath) {
+      return { path, status: !afterPath ? 'missing_upstream' : 'missing_base', auto_merged: false };
+    }
+    const base = upstreamBefore[beforePath];
+    const current = themeFiles[path];
+    const incoming = upstreamAfter[afterPath];
+    if (current === base) {
+      mergedFiles[path] = incoming;
+      return { path, status: 'updated_from_upstream', auto_merged: true };
+    }
+    if (incoming === base || current === incoming) {
+      return { path, status: 'already_compatible', auto_merged: true };
+    }
+    const deltaMerged = applySingleUpstreamDelta(base, current, incoming);
+    if (deltaMerged !== null) {
+      mergedFiles[path] = deltaMerged;
+      return { path, status: 'upstream_delta_applied', auto_merged: true };
+    }
+    return { path, status: 'conflict', auto_merged: false };
+  });
+  return {
+    files: mergedFiles,
+    patch: createProjectPatch(themeFiles, mergedFiles),
+    summary: {
+      checked: results.length,
+      auto_merged: results.filter(item => item.auto_merged).length,
+      conflicts: results.filter(item => item.status === 'conflict').length,
+      missing_upstream: results.filter(item => item.status === 'missing_upstream').length,
+    },
+    results,
+  };
+}
+
+export interface FrontendDiagnostic {
+  code: string;
+  severity: 'error' | 'warning' | 'info';
+  path: string;
+  message: string;
+}
+
+export function auditTemplateFrontend(filesInput: Record<string, string>) {
+  const files = normalizeFiles(filesInput);
+  const diagnostics: FrontendDiagnostic[] = [];
+  for (const [path, content] of Object.entries(files)) {
+    if (path.endsWith('.tpl.php') || path.endsWith('.html')) {
+      for (const match of content.matchAll(/<img\b([^>]*)>/gi)) {
+        if (!/\balt\s*=/.test(match[1]))
+          diagnostics.push({
+            code: 'IMAGE_MISSING_ALT',
+            severity: 'warning',
+            path,
+            message: 'Image is missing an alt attribute.',
+          });
+      }
+      for (const match of content.matchAll(/<a\b([^>]*)>/gi)) {
+        if (
+          /\btarget\s*=\s*['"]_blank['"]/i.test(match[1]) &&
+          !/\brel\s*=\s*['"][^'"]*(?:noopener|noreferrer)/i.test(match[1])
+        )
+          diagnostics.push({
+            code: 'UNSAFE_BLANK_TARGET',
+            severity: 'warning',
+            path,
+            message: 'target="_blank" should use rel="noopener".',
+          });
+      }
+      const ids = [...content.matchAll(/\bid\s*=\s*['"]([^'"?]+)['"]/gi)].map(match => match[1]);
+      for (const id of [...new Set(ids.filter((item, index) => ids.indexOf(item) !== index))])
+        diagnostics.push({
+          code: 'DUPLICATE_HTML_ID',
+          severity: 'error',
+          path,
+          message: `Duplicate HTML id: ${id}`,
+        });
+      const headings = [...content.matchAll(/<h([1-6])\b/gi)].map(match => Number(match[1]));
+      for (let index = 1; index < headings.length; index += 1)
+        if (headings[index] - headings[index - 1] > 1)
+          diagnostics.push({
+            code: 'SKIPPED_HEADING_LEVEL',
+            severity: 'warning',
+            path,
+            message: `Heading level jumps from h${headings[index - 1]} to h${headings[index]}.`,
+          });
+      if (/\becho\s+\$(?!this\b)[a-z_][a-z0-9_]*(?:\[[^\]]+\])?\s*;/i.test(content))
+        diagnostics.push({
+          code: 'POSSIBLE_UNESCAPED_OUTPUT',
+          severity: 'warning',
+          path,
+          message: 'Variable output may require context-aware escaping.',
+        });
+      if (/<html\b(?![^>]*\blang=)/i.test(content))
+        diagnostics.push({
+          code: 'HTML_LANG_MISSING',
+          severity: 'warning',
+          path,
+          message: 'The html element should declare a language.',
+        });
+    }
+    if (path.endsWith('.css')) {
+      const hardcoded = content.match(/#[0-9a-f]{3,8}\b|rgba?\([^)]*\)/gi) ?? [];
+      if (hardcoded.length > 12)
+        diagnostics.push({
+          code: 'MANY_HARDCODED_COLORS',
+          severity: 'info',
+          path,
+          message: `${hardcoded.length} hardcoded colors found; consider design tokens.`,
+        });
+    }
+  }
+  return {
+    is_valid: !diagnostics.some(item => item.severity === 'error'),
+    summary: {
+      errors: diagnostics.filter(item => item.severity === 'error').length,
+      warnings: diagnostics.filter(item => item.severity === 'warning').length,
+      info: diagnostics.filter(item => item.severity === 'info').length,
+    },
+    diagnostics,
+  };
+}
+
+export function extractTemplateDesignTokens(filesInput: Record<string, string>) {
+  const files = normalizeFiles(filesInput);
+  const customProperties: Record<string, string> = {};
+  const colors = new Map<string, number>();
+  const spacing = new Map<string, number>();
+  for (const [path, content] of Object.entries(files)) {
+    if (!/\.(?:css|scss)$/.test(path)) continue;
+    for (const match of content.matchAll(/(--[a-z0-9_-]+)\s*:\s*([^;}]+)[;}]/gi))
+      customProperties[match[1]] = match[2].trim();
+    for (const match of content.matchAll(/#[0-9a-f]{3,8}\b|rgba?\([^)]*\)/gi))
+      colors.set(match[0].toLowerCase(), (colors.get(match[0].toLowerCase()) ?? 0) + 1);
+    for (const match of content.matchAll(
+      /(?:margin|padding|gap)(?:-[a-z]+)?\s*:\s*([0-9.]+(?:px|rem|em))/gi
+    ))
+      spacing.set(match[1], (spacing.get(match[1]) ?? 0) + 1);
+  }
+  const suggestedColors = [...colors].sort((a, b) => b[1] - a[1]).slice(0, 12);
+  const suggestedSpacing = [...spacing].sort((a, b) => b[1] - a[1]).slice(0, 12);
+  const css = [
+    ':root {',
+    ...suggestedColors.map(([value], index) => `  --color-${index + 1}: ${value};`),
+    ...suggestedSpacing.map(([value], index) => `  --space-${index + 1}: ${value};`),
+    '}',
+  ].join('\n');
+  return {
+    existing_custom_properties: customProperties,
+    colors: suggestedColors.map(([value, uses]) => ({ value, uses })),
+    spacing: suggestedSpacing.map(([value, uses]) => ({ value, uses })),
+    suggested_tokens_css: `${css}\n`,
+  };
+}
+
+function positionsFromLayout(content: string): string[] {
+  try {
+    const document = parse(content);
+    const found: string[] = [];
+    const visit = (value: unknown): void => {
+      if (Array.isArray(value)) return value.forEach(visit);
+      if (!value || typeof value !== 'object') return;
+      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        if (key === 'position' && typeof child === 'string') found.push(child);
+        visit(child);
+      }
+    };
+    visit(document);
+    return found;
+  } catch {
+    return [];
+  }
+}
+
+export function auditTemplateWidgetPositions(filesInput: Record<string, string>) {
+  const files = normalizeFiles(filesInput);
+  const rendered = [
+    ...new Set(
+      Object.values(files).flatMap(content =>
+        [...content.matchAll(/\bwidgets\(\s*['"]([^'"]+)['"]/g)].map(match => match[1])
+      )
+    ),
+  ].sort();
+  const checked = [
+    ...new Set(
+      Object.values(files).flatMap(content =>
+        [...content.matchAll(/\bhasWidgetsOn\(\s*['"]([^'"]+)['"]/g)].map(match => match[1])
+      )
+    ),
+  ].sort();
+  const layout = [
+    ...new Set(
+      Object.entries(files)
+        .filter(([path]) => /\.ya?ml$/i.test(path))
+        .flatMap(([, content]) => positionsFromLayout(content))
+    ),
+  ].sort();
+  return {
+    rendered_positions: rendered,
+    guarded_positions: checked,
+    layout_positions: layout,
+    layout_not_rendered: layout.filter(position => !rendered.includes(position)),
+    rendered_not_in_layout: rendered.filter(position => !layout.includes(position)),
+    unguarded_positions: rendered.filter(position => !checked.includes(position)),
+  };
+}
+
+export function scaffoldTemplateE2eEnvironment(options: { theme: string; base_url?: string }) {
+  if (!/^[a-z][a-z0-9_]{1,63}$/.test(options.theme)) throw new Error('Invalid theme name');
+  const baseUrl = options.base_url ?? 'http://web';
+  return {
+    files: {
+      'template-e2e/compose.yaml': `services:\n  web:\n    build: ./php\n    ports: ["8080:80"]\n    volumes:\n      - \${INSTANTCMS_SOURCE:-../instantcms}:/var/www/html\n  db:\n    image: mysql:8.0\n    environment:\n      MYSQL_DATABASE: instantcms\n      MYSQL_USER: instantcms\n      MYSQL_PASSWORD: instantcms\n      MYSQL_ROOT_PASSWORD: root\n  visual:\n    image: mcr.microsoft.com/playwright:v1.52.0-noble\n    working_dir: /tests\n    volumes:\n      - ./:/tests\n    environment:\n      BASE_URL: ${baseUrl}\n    command: ["npx", "playwright", "test"]\n    depends_on: [web]\n`,
+      'template-e2e/php/Dockerfile': `FROM php:8.2-apache\nRUN apt-get update && apt-get install -y libicu-dev libpng-dev libzip-dev unzip && docker-php-ext-install intl mysqli gd zip && rm -rf /var/lib/apt/lists/*\nRUN a2enmod rewrite\n`,
+      'template-e2e/package.json': JSON.stringify(
+        {
+          private: true,
+          devDependencies: { '@playwright/test': '1.52.0' },
+          scripts: { test: 'playwright test', update: 'playwright test --update-snapshots' },
+        },
+        null,
+        2
+      ),
+      'template-e2e/playwright.config.mjs': `import { defineConfig, devices } from '@playwright/test';\nexport default defineConfig({\n  testDir: './tests',\n  outputDir: './artifacts',\n  use: { baseURL: process.env.BASE_URL || 'http://localhost:8080', screenshot: 'only-on-failure' },\n  projects: [\n    { name: 'desktop', use: { ...devices['Desktop Chrome'] } },\n    { name: 'mobile', use: { ...devices['Pixel 7'] } }\n  ]\n});\n`,
+      'template-e2e/tests/template.spec.mjs': `import { test, expect } from '@playwright/test';\nconst pages = (process.env.TEST_PATHS || '/').split(',');\nfor (const path of pages) test(\`${options.theme}: \${path}\`, async ({ page }) => {\n  const errors = [];\n  page.on('console', message => message.type() === 'error' && errors.push(message.text()));\n  page.on('pageerror', error => errors.push(error.message));\n  const response = await page.goto(path, { waitUntil: 'networkidle' });\n  expect(response?.ok()).toBeTruthy();\n  await expect(page).toHaveScreenshot(\`${options.theme}-\${path.replace(/\\W+/g, '-') || 'home'}.png\`, { fullPage: true });\n  expect(errors).toEqual([]);\n});\n`,
+      'template-e2e/.env.example':
+        'INSTANTCMS_SOURCE=../instantcms\nBASE_URL=http://web\nTEST_PATHS=/,/login\n',
+      'template-e2e/README.md': `# ${options.theme} visual tests\n\nMount an installed InstantCMS source tree with this theme enabled, then run:\n\n\`\`\`sh\ndocker compose run --rm visual npm install\ndocker compose run --rm visual npx playwright test --update-snapshots\ndocker compose run --rm visual npx playwright test\n\`\`\`\n\nKeep approved snapshots in version control. Configure INSTANTCMS_SOURCE, BASE_URL and TEST_PATHS in .env.\n`,
+    },
+    notes: [
+      'The InstantCMS source must already be configured for the bundled MySQL service or another reachable database.',
+      'Commit approved screenshots and review diffs in pull requests.',
+      'Run desktop and mobile projects before release.',
+    ],
+  };
+}
+
+export function indexUpstreamTemplateSources(
+  filesInput: Record<string, string>,
+  source: { repository: string; ref: string }
+) {
+  const files = normalizeFiles(filesInput);
+  const templates = Object.entries(files)
+    .filter(([path]) => path.endsWith('.tpl.php'))
+    .map(([path, content]) => {
+      const match = path.match(/(?:^|\/)controllers\/([^/]+)\/(backend\/)?([^/]+)\.tpl\.php$/);
+      return {
+        path,
+        sha256: createHash('sha256').update(content).digest('hex'),
+        bytes: Buffer.byteLength(content),
+        controller: match?.[1] ?? null,
+        action: match?.[3] ?? null,
+        backend: Boolean(match?.[2]),
+        source_url: `https://github.com/${source.repository}/blob/${encodeURIComponent(source.ref)}/${path}`,
+      };
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+  return {
+    repository: source.repository,
+    ref: source.ref,
+    files_indexed: templates.length,
+    controllers: [...new Set(templates.flatMap(item => item.controller ?? []))].sort(),
+    templates,
+  };
+}
+
+export function scaffoldTemplatePhpQuality(options: { theme: string; php_min?: string }) {
+  if (!/^[a-z][a-z0-9_]{1,63}$/.test(options.theme)) throw new Error('Invalid theme name');
+  const phpMin = options.php_min ?? '7.2';
+  if (!/^\d+\.\d+$/.test(phpMin)) throw new Error('php_min must use major.minor format');
+  return {
+    files: {
+      'composer.quality.json': JSON.stringify(
+        {
+          require: { php: `>=${phpMin}` },
+          'require-dev': {
+            'phpstan/phpstan': '^1.12 || ^2.0',
+            'squizlabs/php_codesniffer': '^3.10',
+            'phpcompatibility/php-compatibility': '^9.3',
+            'dealerdirect/phpcodesniffer-composer-installer': '^1.0',
+          },
+          config: { 'allow-plugins': { 'dealerdirect/phpcodesniffer-composer-installer': true } },
+          scripts: {
+            'quality:phpstan': 'phpstan analyse -c phpstan.neon',
+            'quality:phpcs': 'phpcs --standard=phpcs.xml',
+          },
+        },
+        null,
+        2
+      ),
+      'phpstan.neon': `parameters:\n  level: 1\n  paths:\n    - templates/${options.theme}\n  fileExtensions:\n    - php\n  reportUnmatchedIgnoredErrors: false\n`,
+      'phpcs.xml': `<?xml version="1.0"?>\n<ruleset name="InstantCMS template quality">\n  <description>Syntax, style and PHP ${phpMin}+ compatibility for ${options.theme}.</description>\n  <file>templates/${options.theme}</file>\n  <exclude-pattern>*/vendor/*</exclude-pattern>\n  <rule ref="PSR12"/>\n  <rule ref="PHPCompatibility">\n    <properties><property name="testVersion" value="${phpMin}-"/></properties>\n  </rule>\n</ruleset>\n`,
+    },
+    commands: [
+      'COMPOSER=composer.quality.json composer install --no-interaction',
+      'vendor/bin/phpstan analyse -c phpstan.neon',
+      'vendor/bin/phpcs --standard=phpcs.xml',
+    ],
+    notes: [
+      'Merge require-dev entries into the project composer.json instead of replacing existing dependencies.',
+      'Review framework-dependent PHPStan findings before suppressing them.',
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- safely merge clean upstream template changes into overrides and return reviewable Git patches
- audit frontend HTML, accessibility, escaping, CSS, and widget-position consistency
- extract design-token candidates and generate PHPStan/PHPCS/PHPCompatibility configuration
- index upstream templates with SHA-256 provenance and source links
- scaffold Docker Compose and Playwright desktop/mobile visual regression tests
- update theme skill, workflow metadata, architecture, changelog, and README

## Safety
- ambiguous three-way merges remain conflicts and do not modify files
- generated visual tests check HTTP responses, browser console/page errors, and screenshots
- provenance records exact repository ref and content hash

## Validation
- npm run check
- npm run test:integration
- npm run build
- npm run lint
- npm audit --audit-level=high
- generated YAML and ESM visual-test files parsed in unit tests