### PR TITLE
chore(release): 1.2.2 scoped npm publish (@maxisoft-git/instantcms-mcp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.2
+
+- **npm publish fix:** moved the package under the `@maxisoft-git` scope (`@maxisoft-git/instantcms-mcp`) to work around npm's refusal to republish a name that was `npm unpublish`ed in June 2026. The 1.2.1 "Publish to npm" CI job had correctly authenticated (the `NPM_TOKEN` secret is valid) but received `404 Not Found - PUT https://registry.npmjs.org/instantcms-mcp` from the registry. Scoped packages create new name slots and don't require reclaim. Same code, same tests, same public MCP contract — only the npm name changed.
+- All the test-harness improvements from 1.2.1 are included verbatim.
+
 ## 1.2.1
 
 - Significantly expanded automated test coverage: 179 new tests across 13 suites (from 272 to 451 passed), covering property-based serialization/pagination, scaffold-addon round-trip for all 5 types, project workflow edge cases, knowledge lookups, artifact ZIP handling, db-tool invocations, MCP integration smoke, and performance baselines.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ MCP-сервер и набор переносимых AI-workflows для раз
 
 Сервер предоставляет структурированную базу API InstantCMS, безопасные генераторы, валидатор пакетов, диагностические инструменты и MCP resources. Runtime-данные синхронизированы с официальным репозиторием [`instantsoft/icms2`](https://github.com/instantsoft/icms2), последняя проверенная стабильная версия — **InstantCMS 2.18.2**.
 
-Текущий релиз: [`v1.2.1`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.1). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
+Текущий релиз: [`v1.2.2`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.2). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
+
+С версии 1.2.2 пакет публикуется на npm под scoped-именем `@maxisoft-git/instantcms-mcp` (прежнее имя `instantcms-mcp` было `npm unpublish`ed; reclaim пока не сделан):
+
+```bash
+npm install @maxisoft-git/instantcms-mcp
+```
+
+Альтернативно — установка из GitHub Release ZIP: см. секцию [Установка](#требования-и-установка).
 
 ## Возможности
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "instantcms-mcp",
-  "version": "1.2.1",
+  "name": "@maxisoft-git/instantcms-mcp",
+  "version": "1.2.2",
   "description": "MCP server and reusable AI workflows for InstantCMS 2 development",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -30,7 +30,7 @@ describe('MCP integration', () => {
       expect(listed.tools.some(tool => tool.name === 'scaffold_template_php_quality')).toBe(true);
       expect(listed.tools).toHaveLength(100);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
-      expect(result.structuredContent).toMatchObject({ server_version: '1.2.1' });
+      expect(result.structuredContent).toMatchObject({ server_version: '1.2.2' });
     } finally {
       await client.close();
       await server.close();

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -98,7 +98,7 @@ export function registerMetaTools(server: McpServer): void {
     'Версии, профили и объём базы знаний MCP-сервера',
     {},
     () => ({
-      server_version: '1.2.1',
+      server_version: '1.2.2',
       tools_count: 100,
       instantcms_profiles: instantCmsVersionProfiles,
       knowledge: {
@@ -195,7 +195,7 @@ export function registerMetaTools(server: McpServer): void {
     {},
     () => ({
       status: 'ready',
-      server_version: '1.2.1',
+      server_version: '1.2.2',
       tested_instantcms: '2.18.2',
       checks: ['npm run check', 'npm run test:integration', 'npm run build', 'npm audit'],
     })


### PR DESCRIPTION
## Release 1.2.2 — npm publish fix via scoped name

### Problem

The 1.2.1 `Publish to npm` CI job authenticated correctly with the existing `NPM_TOKEN` repository secret, but npm rejected the publish with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/instantcms-mcp - Not found
npm error 404  'instantcms-mcp@1.2.1' is not in this registry.
```

The `instantcms-mcp` name was `npm unpublish`ed in June 2026 (visible at `https://registry.npmjs.org/instantcms-mcp`) and npm blocks republishing under the same name without a maintainer reclaim.

### Fix

Move the package under the `@maxisoft-git` scope:
- `name`: `instantcms-mcp` → `@maxisoft-git/instantcms-mcp`
- `version`: `1.2.1` → `1.2.2` (patch bump)
- `server_version` / `CHANGELOG.md` / `README.md` updated to reflect the new name

The existing `.github/workflows/release.yml` already runs `npm publish --access public`, which is correct for scoped packages.

### Install

```bash
npm install @maxisoft-git/instantcms-mcp
```

Or, as before, install from a GitHub Release ZIP.

### Verification plan

After this PR merges:
1. Tag `v1.2.2` is pushed.
2. The `Release` workflow runs; the `Publish to npm` step should now succeed (no 404 on a fresh name).
3. `https://www.npmjs.com/package/@maxisoft-git/instantcms-mcp` is the npm landing page.

The 1.2.1 release notes (test-harness expansion: 179 new tests, 13 suites, defineTool, find_tool, +2525 lines of test code) apply verbatim — there are no code or test changes in this release.