### PR TITLE
chore: set publishConfig.access=public in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
       "prettier --write"
     ]
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "fast-xml-parser": "^5.11.0",


### PR DESCRIPTION
## Context

The v1.2.2 'Publish to npm' CI job failed with 404 (PUT to a fresh scoped name) — debug showed that the existing `NPM_TOKEN` repository secret lacks the `publish:create-packages` scope, so creating the brand-new scoped package from CI isn't possible without rotating the token.

A subsequent manual `npm publish` from the user shell failed with `E402 Payment Required - You must sign up for private packages` because npm defaults to `access=private` for scoped names when invoked without `--access public`.

## Fix

Add a default `publishConfig.access: "public"` so any plain `npm publish` invocation publishes as public without needing the CLI flag.



The CI workflow continues to pass `--access public` explicitly for clarity.

This does not by itself unlock CI publishing — for that a maintainer needs to rotate the repository `NPM_TOKEN` secret with a fresh automation token that has 'All packages' / 'Read and write' permissions. See the companion note in the v1.2.2 release description for the regenerate-and-replace steps.