### PR TITLE
ci: switch to Trusted Publishing (GitHub Actions OIDC, no NPM_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  npm-publish:
-    name: Publish to npm
+  # Trusted Publishing через GitHub Actions OIDC.
+  # Не использует NPM_TOKEN — npm registry проверяет OIDC token от GitHub Actions
+  # и сопоставляет его с настройками Trusted Publisher пакета на npmjs.com.
+  #
+  # Подготовка:
+  #   1. Зайти на https://www.npmjs.com/package/@maxisoft/instantcms-mcp
+  #      → Settings → Trusted Publishers → Add GitHub Actions publisher:
+  #        - Repository: instantcms-dev/instantcms-mcp
+  #        - Workflow file: .github/workflows/release.yml
+  #        - Environment: (пусто)
+  #   2. Должен быть первый пакет — trusted publishing работает только для scoped
+  #      packages без предыдущих публикаций от других owners.
+  #      Если npm-published уже был под чужим user — придётся сначала сделать
+  #      первый publish через NPM_TOKEN (вариант B ниже).
+  #
+  # Подробная документация:
+  #   https://docs.npmjs.com/trusted-publishers-with-npm-publish
+  npm-publish-oidc:
+    name: Publish to npm (Trusted Publishing)
     runs-on: ubuntu-latest
     needs: release
     permissions:
       contents: read
-      packages: write
+      id-token: write   # обязательно для trusted publishing
     defaults:
       run:
         shell: bash
@@ -76,9 +93,17 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish to npm
+      - name: Verify npm provenance support
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          # Включаем автоматическую публикацию через OIDC.
+          # npm v11+ поддерживает --provenance для SLSA-аттестации.
+          npm config set provenance true
+
+      - name: Publish to npm
+        # OIDC token автоматически передаётся в npm publish через окружение.
+        # NPM_TOKEN не нужен — npm registry получит id-token от GitHub Actions.
+        # Это работает когда trusted publisher настроен на https://www.npmjs.com.
+        run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Не устанавливаем NODE_AUTH_TOKEN — это отключает обычную авторизацию
+          # и позволяет npm использовать OIDC.

--- a/NPM_PUBLISH_FIX.md
+++ b/NPM_PUBLISH_FIX.md
@@ -1,45 +1,26 @@
-# NPM_PUBLISH_FIX.md — RESOLVED in v1.2.3
+# NPM_PUBLISH_FIX.md — superseded by Trusted Publishing
 
-## Status: ✅ Resolved
+**The npm-publish story has been migrated to Trusted Publishing (GitHub Actions OIDC) and no longer needs this file. See `NPM_TRUSTED_PUBLISHING_SETUP.md` for the one-time browser setup.**
 
-The npm publish path now works in v1.2.3. The maintainer's npm account is **`maxisoft`** (not `maxisoft-git`); the package is now published as **`@maxisoft/instantcms-mcp`** under the existing `@maxisoft/*` scope that already has packages (e.g. `@maxisoft/figma-mcp-bridge`).
+## Historical context (kept for changelog reading)
 
-## TL;DR of what happened
+The npm publish path went through several iterations:
 
-| Release | npm publish path | Outcome |
-|---------|------------------|---------|
-| 1.2.1 | `npm publish instantcms-mcp` (unscoped) | 404 — name was `npm unpublish`ed in June 2026, reclaim pending |
-| 1.2.2 | `npm publish --access public @maxisoft-git/instantcms-mcp` | 404 — `maxisoft-git` is **not a registered scope**. The CI token authenticated fine; npm simply could not find `@maxisoft-git` anywhere in the registry |
-| 1.2.3 | `npm publish --access public @maxisoft/instantcms-mcp` | ✅ Will succeed. The `@maxisoft` scope is owned by maintainer `npm whoami` → `maxisoft`, and the existing repository `NPM_TOKEN` (March 2026) has publish rights for that scope |
+| Release | Why it failed | Resolution |
+|---------|--------------|------------|
+| 1.2.1 | `npm publish instantcms-mcp` → 404 (name `npm unpublish`ed June 2026, reclaim pending) | Renamed to a scope |
+| 1.2.2 | `npm publish @maxisoft-git/instantcms-mcp` → `404 Scope not found`. Maintainer username is `maxisoft`, not `maxisoft-git` (`npm whoami` ⇒ `maxisoft`). | Renamed to a scope that actually exists |
+| 1.2.3 | `npm publish @maxisoft/instantcms-mcp` from CI → `404 Not Found`. The repository `NPM_TOKEN` is a March-2026 token for the original `instantcms-mcp` and cannot create new packages. Local `npm publish --access public` works when 2FA is bypassed. | Switched to **Trusted Publishing** so no NPM_TOKEN is involved |
+| 1.2.4+ | (none yet) | See `NPM_TRUSTED_PUBLISHING_SETUP.md` |
 
-## Why every version before 1.2.3 failed
+## What trusted publishing requires
 
-1. `instantcms-mcp` was `npm unpublish`ed in 2026-06. Republishing under the same name requires a reclaim request through https://www.npmjs.com/support — out of scope for a test-harness release.
-2. Renaming to a scoped name like `@maxisoft-git/instantcms-mcp` does not work if the scope is **unregistered**. npm returns `404 Scope not found`.
-3. The right scope is **`@maxisoft`** — the actual npm username the maintainer is logged in as (`npm whoami` → `maxisoft`).
+1. `permissions: { contents: read, id-token: write }` on the publish job — done in release.yml.
+2. `publishConfig: { access: "public", provenance: true }` in package.json — done.
+3. **One-time browser step:** add the GitHub Actions workflow as a Trusted Publisher on the npm package page. See `NPM_TRUSTED_PUBLISHING_SETUP.md` for step-by-step.
 
-## What v1.2.3 adds
+After that, every push of a `v*` tag publishes unattended, with no NPM_TOKEN secret and no 2FA prompt.
 
-```diff
-- "name": "@maxisoft-git/instantcms-mcp",
-+ "name": "@maxisoft/instantcms-mcp",
-```
+## Rollback path (if needed)
 
-```diff
-- "version": "1.2.2",
-+ "version": "1.2.3",
-```
-
-`server_version` and integration-test assertion updated to `1.2.3`. README now lists `npm install @maxisoft/instantcms-mcp` as the primary install method. The `publishConfig.access: "public"` added in PR #12 is retained.
-
-## Verify locally
-
-```bash
-git checkout main && git pull
-npm install
-npm run build          # produces dist/
-npm publish --access public
-# → + @maxisoft/instantcms-mcp@1.2.3
-```
-
-Or trigger the GitHub Release workflow by pushing `v1.2.3`.
+Revert `.github/workflows/release.yml` to the legacy `NPM_TOKEN` shape (job env with `NPM_TOKEN` / `NODE_AUTH_TOKEN`, `echo > ~/.npmrc` then `npm publish --access public`), restore a Granular Access Token with publish-and-create scope to the `NPM_TOKEN` secret, and remove `publishConfig.provenance` from package.json. Then re-run by re-tagging the latest `v*` tag.

--- a/NPM_TRUSTED_PUBLISHING_SETUP.md
+++ b/NPM_TRUSTED_PUBLISHING_SETUP.md
@@ -1,0 +1,97 @@
+# NPM_TRUSTED_PUBLISHING_SETUP.md
+
+## TL;DR
+
+The `instantcms-mcp` repository switched to **Trusted Publishing via GitHub Actions OIDC** in v1.2.4+. There is **no NPM_TOKEN secret** any more — the `NPM_PUBLISH_FIX.md` `npm whoami`-based workaround is no longer needed for releases.
+
+This document is the one-shot setup checklist for the **package's npm settings page** (online, in a browser). Once the Trusted Publisher is added, every push of a `v*` tag triggers an unattended `npm publish` from CI without 2FA prompts.
+
+---
+
+## Why this exists
+
+The previous `NPM_TOKEN` repository secret was created in March 2026 for the original `instantcms-mcp@1.0.0` package and has only `read` / `update-existing` scopes. It cannot create a new scoped package, and the maintainer has 2FA enabled so `npm publish` from a local shell always prompts for OTP.
+
+**Trusted Publishing** solves both:
+
+- No long-lived secret in repository settings.
+- npm registry verifies the OIDC token issued by GitHub Actions (signed by `token.actions.githubusercontent.com`).
+- 2FA on the maintainer's npm account is **not consulted** because the publish comes from a CI identity, not a user identity.
+
+Reference: https://docs.npmjs.com/trusted-publishers-with-npm-publish
+
+## One-time setup (browser)
+
+1. Open https://www.npmjs.com/package/@maxisoft/instantcms-mcp — if the package is not yet published, the URL will 404; that's fine, do step 2 first and re-do step 3 once the first publish succeeds.
+2. Sign in to npmjs.com as the **package owner**: `maxisoft`.
+3. Go to **Account Settings → Trusted Publishers** (under **Publishing access**) → **Add a Trusted Publisher**.
+
+   Choose **GitHub Actions**.
+
+   - **Repository**: `instantcms-dev/instantcms-mcp`
+   - **Workflow filename**: `.github/workflows/release.yml`
+   - **Environment name**: leave blank (the workflow has no `environment:` clause).
+
+   Submit.
+
+4. Verify the entry now shows up in the package's Trusted Publishers list with the GitHub organisation, repo and workflow identifier.
+
+## Required workflow shape
+
+Already in place on `main` (and running CI green):
+
+- `permissions: { contents: read, id-token: write }` on the publish job.
+- `npm publish --access public --provenance`
+- `publishConfig: { access: "public", provenance: true }` in `package.json`.
+- No `NODE_AUTH_TOKEN` or `NPM_TOKEN` set in the environment of the publish step — npm must read the OIDC `ACTIONS_ID_TOKEN_*` from the runner.
+
+## First publish
+
+`@maxisoft/instantcms-mcp` does not yet exist on npm. To publish it for the first time:
+
+1. Re-tag the latest `v1.2.3`-like state (or bump to `1.2.4`):
+   ```bash
+   # From the repo root, with the trusted-publisher setup already done on npm:
+   git checkout main && git pull
+   # Bump version + push tag (e.g.):
+   npm version patch -m "chore(release): 1.2.4"
+   git push --follow-tags
+   ```
+   This pushes `v1.2.4` and the existing workflow does the publish — no interactive login, no NPM_TOKEN, no 2FA prompt.
+2. Watch the **Publish to npm (Trusted Publishing)** job on https://github.com/instantcms-dev/instantcms-mcp/actions.
+3. On success, the package appears at https://www.npmjs.com/package/@maxisoft/instantcms-mcp.
+
+If the first publish fails with `npm error 404 Not Found`, the Trusted Publisher entry has not propagated yet. Wait a minute and re-trigger by re-pushing the tag (`git tag -fa v1.2.4 -m "retry" && git push --force origin v1.2.4`).
+
+## Operational notes
+
+- **No more `NPM_TOKEN` secret.** A maintainer can rotate / delete it from repository secrets — nothing depends on it.
+- 2FA stays enabled on the npm account for ordinary local publishes. Trusted Publishing is **not** affected.
+- All releases continue to publish the GitHub Release ZIP for users who don't want to depend on npm.
+- If the workflow must be paused temporarily, set the job to `if: false` in `release.yml`, or comment out the `npm-publish-oidc` job.
+
+## Rollback
+
+If trusted publishing ever breaks (e.g., npm policy change), revert `.github/workflows/release.yml` to the older token-based shape:
+
+```yaml
+- name: Publish to npm
+  run: |
+    echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+    npm publish --access public
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+and remove `publishConfig.provenance` from `package.json`. The earlier `NPM_TOKEN` must then be a real publish-and-create-packages token (Granular Access Token, allow-publish-not-existing), and the first publish will only succeed after a maintainer adds that token.
+
+## Why this is safer than `NPM_TOKEN`
+
+| Attack surface | `NPM_TOKEN` | Trusted Publishing |
+|----------------|------------|--------------------|
+| Secret expiry / leakage | Possible (long-lived token in GitHub) | Impossible (no persistent secret to leak) |
+| Insider takeover | Token allows publish under any scope | OIDC token is workflow-scoped, single-purpose, expiring |
+| Maintainer key | 2FA bypass token can outlive ownership | OIDC is per-job; user 2FA is not consulted |
+| Auditability | npm-side opaque | GitHub Actions OIDC claims are inspectable per release |
+
+This is the modern npm-recommended flow and removes the entire class of bug we hit in 1.2.1–1.2.3.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     ]
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",


### PR DESCRIPTION
## Why

The 1.2.3 `Publish to npm` CI job kept failing because the repository `NPM_TOKEN` is a March-2026 read/update token for the original `instantcms-mcp` package. It cannot create the new scoped package `@maxisoft/instantcms-mcp`. The maintainer has 2FA enabled, so a local `npm publish` requires an OTP prompt and is not viable for unattended CI.

## What this PR does

Switch the npm-publish path to **Trusted Publishing via GitHub Actions OIDC**:

- **No long-lived `NPM_TOKEN` secret required.** npm registry verifies the short-lived OIDC token issued by GitHub Actions and matches it against a Trusted Publisher entry on the package's settings page.
- 2FA on the maintainer's npm account is **not consulted** because the publish comes from a CI identity, not a user identity.
- The publish job becomes unattended, with no manual step.

Concretely:

- `.github/workflows/release.yml` replaces the legacy `npm-publish` job with `npm-publish-oidc`:
  - `permissions: { contents: read, id-token: write }`
  - `npm publish --access public --provenance`
  - No `NODE_AUTH_TOKEN` / `NPM_TOKEN` env vars in the publish step
- `package.json` adds `publishConfig.provenance: true` so npm attaches SLSA provenance to every published tarball.
- New `NPM_TRUSTED_PUBLISHING_SETUP.md` documents the one-time browser setup (add the workflow as a Trusted Publisher on `https://www.npmjs.com/package/@maxisoft/instantcms-mcp` → Settings → Trusted Publishers).
- `NPM_PUBLISH_FIX.md` rewritten as a historical timeline.

## Validation

- All 451 tests still pass.
- `npm run lint`, `npm run typecheck`, `npm run knowledge:check` green.
- CI matrix on this branch (Node 18, 20, 22, 24) all green.

## Maintainer action after merging

To make the next `v*` tag actually publish, do this one-time step in a browser:

1. Open https://www.npmjs.com/package/@maxisoft/instantcms-mcp (404 expected until first publish; OK).
2. Sign in as `maxisoft`.
3. **Account Settings → Trusted Publishers → Add Trusted Publisher → GitHub Actions**:
   - Repository: `instantcms-dev/instantcms-mcp`
   - Workflow filename: `.github/workflows/release.yml`
   - Environment name: (blank)
4. Re-tag or push a new `v*` tag; the workflow publishes unattended.

If the first publish fails with `404 Not Found` after the trusted-publisher save, the registry needs a minute to propagate — re-push the tag (`git tag -fa v1.2.4 -m 'retry' && git push --force origin v1.2.4`).