### PR TITLE
chore(release): 1.2.4 — bump for first Trusted Publishing release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.4
+
+- **First central npm publish via Trusted Publishing.** The 1.2.x series had a long-running `NPM_TOKEN`-related failure (1.2.1: name unpublished; 1.2.2: scope `maxisoft-git` not registered; 1.2.3: token scope invalid). This release switches the CI workflow to **GitHub Actions OpenID Connect** as the authentication mechanism, replacing the persistent `NPM_TOKEN` secret with a short-lived OIDC id-token verified by the npm registry against the package's Trusted Publisher entry. No 2FA prompt at publish time, no long-lived token to leak. The full setup walkthrough is in `NPM_TRUSTED_PUBLISHING_SETUP.md`.
+- Same code, same tests, same public MCP contract. The `--provenance` flag is now enabled in the publish step so npm attaches SLSA provenance attestations to every published tarball.
+- Version bump `1.2.3 → 1.2.4` (patch).
+
 ## 1.2.3
 
 - **npm publish fix (real solution):** the maintainer's npm **username is `maxisoft`**, not `maxisoft-git`. The 1.2.2 attempt chose `@maxisoft-git/instantcms-mcp`, an unregistered scope, which `npm` correctly rejected with `404 Scope not found`. This release renames the package to **`@maxisoft/instantcms-mcp`**, an already-published scope (existing package `@maxisoft/figma-mcp-bridge`). The `NPM_TOKEN` already in the repo (created March 2026) has publish rights to `@maxisoft/*`, so this is the first version that should actually publish to the central npm registry.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 
 Сервер предоставляет структурированную базу API InstantCMS, безопасные генераторы, валидатор пакетов, диагностические инструменты и MCP resources. Runtime-данные синхронизированы с официальным репозиторием [`instantsoft/icms2`](https://github.com/instantsoft/icms2), последняя проверенная стабильная версия — **InstantCMS 2.18.2**.
 
-Текущий релиз: [`v1.2.3`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.3). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
+Текущий релиз: [`v1.2.4`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.4). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
 
 ### Установка
 
@@ -17,11 +17,11 @@ MCP-сервер и набор переносимых AI-workflows для раз
 npm install @maxisoft/instantcms-mcp
 ```
 
-Пакет `instantcms-mcp` был `npm unpublish`ed в июне 2026, поэтому release 1.2.3 публикуется на npm под scope `@maxisoft` (существующий npm-account проекта). Альтернативно — из GitHub Release ZIP:
+Это **первый релиз, опубликованный на центральном npm-реестре** через Trusted Publishing (GitHub Actions OpenID Connect). Пакет `instantcms-mcp` был `npm unpublish`ed в июне 2026, поэтому имя скопировано под scope `@maxisoft`. Для пользователей без доверия к npm также доступен GitHub Release ZIP:
 
 ```bash
-curl -L -O https://github.com/instantcms-dev/instantcms-mcp/releases/download/v1.2.3/instantcms-mcp-v1.2.3.zip
-unzip instantcms-mcp-v1.2.3.zip && cd instantcms-mcp-*/release
+curl -L -O https://github.com/instantcms-dev/instantcms-mcp/releases/download/v1.2.4/instantcms-mcp-v1.2.4.zip
+unzip instantcms-mcp-v1.2.4.zip && cd instantcms-mcp-*/release
 npm install --production
 node dist/index.js
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxisoft/instantcms-mcp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "MCP server and reusable AI workflows for InstantCMS 2 development",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -30,7 +30,7 @@ describe('MCP integration', () => {
       expect(listed.tools.some(tool => tool.name === 'scaffold_template_php_quality')).toBe(true);
       expect(listed.tools).toHaveLength(100);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
-      expect(result.structuredContent).toMatchObject({ server_version: '1.2.3' });
+      expect(result.structuredContent).toMatchObject({ server_version: '1.2.4' });
     } finally {
       await client.close();
       await server.close();

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -98,7 +98,7 @@ export function registerMetaTools(server: McpServer): void {
     'Версии, профили и объём базы знаний MCP-сервера',
     {},
     () => ({
-      server_version: '1.2.3',
+      server_version: '1.2.4',
       tools_count: 100,
       instantcms_profiles: instantCmsVersionProfiles,
       knowledge: {
@@ -195,7 +195,7 @@ export function registerMetaTools(server: McpServer): void {
     {},
     () => ({
       status: 'ready',
-      server_version: '1.2.3',
+      server_version: '1.2.4',
       tested_instantcms: '2.18.2',
       checks: ['npm run check', 'npm run test:integration', 'npm run build', 'npm audit'],
     })


### PR DESCRIPTION
## v1.2.4 — first publish via Trusted Publishing

Bumps the package to `1.2.4` so the upcoming `v1.2.4` tag is the trigger for the first OIDC-mediated npm publish.

- `package.json` `version`: `1.2.3 → 1.2.4`
- `server_version` and integration test assertion updated to `1.2.4`
- README/CHANGELOG updated to reflect the new release

The Trusted Publisher at `https://www.npmjs.com/package/@maxisoft/instantcms-mcp` is configured to trust `.github/workflows/release.yml` on `instantcms-dev/instantcms-mcp`. After this PR merges, pushing `v1.2.4` will publish `@maxisoft/instantcms-mcp@1.2.4` to the central npm registry without a token, without 2FA prompts, and without any long-lived secret.

All 451 tests pass; `npm run check` green.