### PR TITLE
fix(ci): drop empty env block, scope permissions per-job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,12 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -93,17 +92,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Verify npm provenance support
-        run: |
-          # Включаем автоматическую публикацию через OIDC.
-          # npm v11+ поддерживает --provenance для SLSA-аттестации.
-          npm config set provenance true
-
       - name: Publish to npm
         # OIDC token автоматически передаётся в npm publish через окружение.
         # NPM_TOKEN не нужен — npm registry получит id-token от GitHub Actions.
         # Это работает когда trusted publisher настроен на https://www.npmjs.com.
         run: npm publish --access public --provenance
-        env:
-          # Не устанавливаем NODE_AUTH_TOKEN — это отключает обычную авторизацию
-          # и позволяет npm использовать OIDC.


### PR DESCRIPTION
## Fix

The v1.2.4 Release workflow failed with 'workflow file issue' because the OIDC publish step had an `env:` block whose key/value body was empty after stripping comments — the GitHub Actions schema validator rejects empty-env blocks.

## Changes

```diff
-  - name: Publish to npm
-    run: npm publish --access public --provenance
-    env:
-      # Не устанавливаем NODE_AUTH_TOKEN ...
+  - name: Publish to npm
+    run: npm publish --access public --provenance
```

Also moved workflow-level `permissions: contents: write` down to the `release` job, so the OIDC-publish job's explicit `id-token: write` permission request doesn't conflict with implicit contents: write at workflow scope.

And removed a redundant `npm config set provenance true` step — provenance is already enabled via `package.json#publishConfig.provenance: true`.

## Re-trigger

After merge, re-trigger the publish:

```bash
git checkout main && git pull
git tag -fa v1.2.4 -m 'Re-run 1.2.4 Trusted Publishing' &&   git push --force origin v1.2.4
```

This re-runs the Release workflow against the fixed `release.yml` and the already-configured npm Trusted Publisher. Should publish `@maxisoft/instantcms-mcp@1.2.4` to the central npm registry.