### PR TITLE
fix(ci): exchange OIDC id-token for npm publish (Trusted Publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,26 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Получаем OIDC id-token от GitHub Actions для Trusted Publisher.
+      # npm CLI напрямую не использует ACTIONS_ID_TOKEN_*, поэтому обмениваем
+      # id-token через actions/github-script и передаём его npm как обычный
+      # Bearer authToken. Trusted Publisher на npmjs.com верифицирует именно
+      # этот JWT — поэтому NPM_TOKEN как secret больше не нужен.
+      - name: Get OIDC token for npmjs
+        id: oidc
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('npmjs.com');
+            core.setOutput('token', token);
+
       - name: Publish to npm
-        # OIDC token автоматически передаётся в npm publish через окружение.
-        # NPM_TOKEN не нужен — npm registry получит id-token от GitHub Actions.
-        # Это работает когда trusted publisher настроен на https://www.npmjs.com.
-        run: npm publish --access public --provenance
+        # npm CLI не читает ACTIONS_ID_TOKEN_* автоматически, поэтому
+        # подставляем полученный JWT как обычный Bearer-token. npm пошлёт
+        # его в Authorization: Bearer, npm registry сверит подпись и owner
+        # через Trusted Publisher entry (см. NPM_TRUSTED_PUBLISHING_SETUP.md).
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
+          npm publish --access public --provenance
+        env:
+          TOKEN: ${{ steps.oidc.outputs.token }}


### PR DESCRIPTION
## Fix

The v1.2.4 Release workflow's OIDC publish step fails with `ENEEDAUTH` because npm CLI does **not** automatically consume `ACTIONS_ID_TOKEN_*` environment variables when no `~/.npmrc` auth token is set.

## Fix

Add a step that fetches the GitHub Actions id-token via `actions/github-script`:

```yaml
- name: Get OIDC token for npmjs
  id: oidc
  uses: actions/github-script@v7
  with:
    script: |
      const token = await core.getIDToken('npmjs.com');
      core.setOutput('token', token);

- name: Publish to npm
  run: |
    echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
    npm publish --access public --provenance
  env:
    TOKEN: ${{ steps.oidc.outputs.token }}
```

npm registry verifies the JWT signature and grants publish access against the package's Trusted Publisher entry. No persistent `NPM_TOKEN` secret required; 2FA on the maintainer's npm account is not consulted.

Reference: https://docs.npmjs.com/trusted-publishers-with-npm-publish

## Re-trigger after merge

```bash
git tag -fa v1.2.4 -m 'Re-run 1.2.4 Trusted Publishing' && \
  git push --force origin v1.2.4
```