### PR TITLE
fix(ci): native npm trusted publishing and release 1.2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,15 @@ jobs:
       # id-token через actions/github-script и передаём его npm как обычный
       # Bearer authToken. Trusted Publisher на npmjs.com верифицирует именно
       # этот JWT — поэтому NPM_TOKEN как secret больше не нужен.
-      - name: Get OIDC token for npmjs
+      - name: Get OIDC token for npm registry
         id: oidc
         uses: actions/github-script@v7
         with:
+          # npm registry verifies the JWT against audience 'npm:registry.npmjs.org'
+          # (per https://docs.npmjs.com/trusted-publishers-with-npm-publish).
+          # Using a different audience — e.g. 'npmjs.com' — is rejected with 404.
           script: |
-            const token = await core.getIDToken('npmjs.com');
+            const token = await core.getIDToken('npm:registry.npmjs.org');
             core.setOutput('token', token);
 
       - name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
 
 jobs:
   release:
@@ -14,18 +23,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '24'
+
+      - name: Verify release version
+        run: |
+          node <<'NODE'
+          const pkg = require('./package.json');
+          const lock = require('./package-lock.json');
+          if (process.env.RELEASE_TAG !== `v${pkg.version}`) {
+            throw new Error('Release tag must match v' + pkg.version);
+          }
+          if (lock.name !== pkg.name || lock.version !== pkg.version ||
+              lock.packages[''].name !== pkg.name || lock.packages[''].version !== pkg.version) {
+            throw new Error('package-lock.json must match package.json');
+          }
+          NODE
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test
+      - name: Run checks
+        run: npm run check
 
       - name: Build
         run: npm run build
@@ -40,32 +64,19 @@ jobs:
           cp package.json release/
           cp README.md release/
           cp LICENSE release/ || true
-          cd release && zip -r ../instantcms-mcp-${{ github.ref_name }}.zip .
+          cd release && zip -r "../instantcms-mcp-${RELEASE_TAG}.zip" .
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:
-          files: instantcms-mcp-${{ github.ref_name }}.zip
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: instantcms-mcp-${{ env.RELEASE_TAG }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Trusted Publishing через GitHub Actions OIDC.
-  # Не использует NPM_TOKEN — npm registry проверяет OIDC token от GitHub Actions
-  # и сопоставляет его с настройками Trusted Publisher пакета на npmjs.com.
-  #
-  # Подготовка:
-  #   1. Зайти на https://www.npmjs.com/package/@maxisoft/instantcms-mcp
-  #      → Settings → Trusted Publishers → Add GitHub Actions publisher:
-  #        - Repository: instantcms-dev/instantcms-mcp
-  #        - Workflow file: .github/workflows/release.yml
-  #        - Environment: (пусто)
-  #   2. Должен быть первый пакет — trusted publishing работает только для scoped
-  #      packages без предыдущих публикаций от других owners.
-  #      Если npm-published уже был под чужим user — придётся сначала сделать
-  #      первый publish через NPM_TOKEN (вариант B ниже).
-  #
-  # Подробная документация:
-  #   https://docs.npmjs.com/trusted-publishers-with-npm-publish
+  # npm CLI exchanges GitHub OIDC credentials automatically.
+  # Configure the package's Trusted Publisher with workflow filename release.yml.
+  # See NPM_TRUSTED_PUBLISHING_SETUP.md.
   npm-publish-oidc:
     name: Publish to npm (Trusted Publishing)
     runs-on: ubuntu-latest
@@ -79,12 +90,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '24'
+
+      - name: Install npm with Trusted Publishing support
+        # OIDC requires npm >=11.5.1 and Node >=22.14.0.
+        run: npm install --global npm@11.18.0 --registry=https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -92,29 +108,26 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Получаем OIDC id-token от GitHub Actions для Trusted Publisher.
-      # npm CLI напрямую не использует ACTIONS_ID_TOKEN_*, поэтому обмениваем
-      # id-token через actions/github-script и передаём его npm как обычный
-      # Bearer authToken. Trusted Publisher на npmjs.com верифицирует именно
-      # этот JWT — поэтому NPM_TOKEN как secret больше не нужен.
-      - name: Get OIDC token for npm registry
-        id: oidc
-        uses: actions/github-script@v7
-        with:
-          # npm registry verifies the JWT against audience 'npm:registry.npmjs.org'
-          # (per https://docs.npmjs.com/trusted-publishers-with-npm-publish).
-          # Using a different audience — e.g. 'npmjs.com' — is rejected with 404.
-          script: |
-            const token = await core.getIDToken('npm:registry.npmjs.org');
-            core.setOutput('token', token);
+      - name: Check whether version is already published
+        id: published
+        run: |
+          node --input-type=module <<'NODE'
+          import { readFileSync, appendFileSync } from 'node:fs';
+          const { name, version } = JSON.parse(readFileSync('package.json', 'utf8'));
+          const response = await fetch(
+            `https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
+            { signal: AbortSignal.timeout(30000) }
+          );
+          if (response.status !== 200 && response.status !== 404) {
+            throw new Error(`npm registry check failed: HTTP ${response.status}`);
+          }
+          appendFileSync(process.env.GITHUB_OUTPUT, `exists=${response.status === 200}\n`);
+          if (response.status === 200) console.log(`${name}@${version} is already published; skipping.`);
+          NODE
 
       - name: Publish to npm
-        # npm CLI не читает ACTIONS_ID_TOKEN_* автоматически, поэтому
-        # подставляем полученный JWT как обычный Bearer-token. npm пошлёт
-        # его в Authorization: Bearer, npm registry сверит подпись и owner
-        # через Trusted Publisher entry (см. NPM_TRUSTED_PUBLISHING_SETUP.md).
-        run: |
-          echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
-          npm publish --access public --provenance
+        if: steps.published.outputs.exists != 'true'
+        # No NODE_AUTH_TOKEN, raw JWT or manually written .npmrc is needed.
+        run: npm publish --access public --provenance --registry=https://registry.npmjs.org --tag "$NPM_DIST_TAG"
         env:
-          TOKEN: ${{ steps.oidc.outputs.token }}
+          NPM_DIST_TAG: ${{ (github.event.release.prerelease || contains(env.RELEASE_TAG, '-')) && 'next' || 'latest' }}

--- a/NPM_PUBLISH_FIX.md
+++ b/NPM_PUBLISH_FIX.md
@@ -1,26 +1,9 @@
-# NPM_PUBLISH_FIX.md — superseded by Trusted Publishing
+# npm publication fix
 
-**The npm-publish story has been migrated to Trusted Publishing (GitHub Actions OIDC) and no longer needs this file. See `NPM_TRUSTED_PUBLISHING_SETUP.md` for the one-time browser setup.**
+The release run [33304149534](https://github.com/instantcms-dev/instantcms-mcp/actions/runs/33304149534) failed on 2026-08-30 with `E404` while publishing `@maxisoft/instantcms-mcp@1.2.4`. The registry already contained `1.2.3`.
 
-## Historical context (kept for changelog reading)
+The workflow used Node.js 20 and manually passed a GitHub OIDC JWT as an npm `_authToken`. Trusted Publishing requires a supported npm CLI to perform the credential exchange. Changing the JWT audience alone does not fix this flow.
 
-The npm publish path went through several iterations:
+The correction uses Node.js 24 and npm 11.18.0 with native OIDC authentication, adds the repository metadata required for provenance, and synchronizes the package-lock name/version. The workflow handles tag pushes and published GitHub Releases, validates the release version, and skips an already published version.
 
-| Release | Why it failed | Resolution |
-|---------|--------------|------------|
-| 1.2.1 | `npm publish instantcms-mcp` → 404 (name `npm unpublish`ed June 2026, reclaim pending) | Renamed to a scope |
-| 1.2.2 | `npm publish @maxisoft-git/instantcms-mcp` → `404 Scope not found`. Maintainer username is `maxisoft`, not `maxisoft-git` (`npm whoami` ⇒ `maxisoft`). | Renamed to a scope that actually exists |
-| 1.2.3 | `npm publish @maxisoft/instantcms-mcp` from CI → `404 Not Found`. The repository `NPM_TOKEN` is a March-2026 token for the original `instantcms-mcp` and cannot create new packages. Local `npm publish --access public` works when 2FA is bypassed. | Switched to **Trusted Publishing** so no NPM_TOKEN is involved |
-| 1.2.4+ | (none yet) | See `NPM_TRUSTED_PUBLISHING_SETUP.md` |
-
-## What trusted publishing requires
-
-1. `permissions: { contents: read, id-token: write }` on the publish job — done in release.yml.
-2. `publishConfig: { access: "public", provenance: true }` in package.json — done.
-3. **One-time browser step:** add the GitHub Actions workflow as a Trusted Publisher on the npm package page. See `NPM_TRUSTED_PUBLISHING_SETUP.md` for step-by-step.
-
-After that, every push of a `v*` tag publishes unattended, with no NPM_TOKEN secret and no 2FA prompt.
-
-## Rollback path (if needed)
-
-Revert `.github/workflows/release.yml` to the legacy `NPM_TOKEN` shape (job env with `NPM_TOKEN` / `NODE_AUTH_TOKEN`, `echo > ~/.npmrc` then `npm publish --access public`), restore a Granular Access Token with publish-and-create scope to the `NPM_TOKEN` secret, and remove `publishConfig.provenance` from package.json. Then re-run by re-tagging the latest `v*` tag.
+A package owner must also configure the matching Trusted Publisher on npmjs.com. See [NPM_TRUSTED_PUBLISHING_SETUP.md](NPM_TRUSTED_PUBLISHING_SETUP.md) for exact values and retry instructions. Do not work around a failure by disabling 2FA, writing a raw JWT to `.npmrc`, or force-moving release tags.

--- a/NPM_TRUSTED_PUBLISHING_SETUP.md
+++ b/NPM_TRUSTED_PUBLISHING_SETUP.md
@@ -1,97 +1,60 @@
-# NPM_TRUSTED_PUBLISHING_SETUP.md
+# npm Trusted Publishing setup
 
-## TL;DR
+Releases publish `@maxisoft/instantcms-mcp` through GitHub Actions OIDC, without an `NPM_TOKEN` secret. The package already exists: the public registry reported version `1.2.3` on 2026-08-30. The failed `v1.2.4` publish does not mean the package needs to be created again.
 
-The `instantcms-mcp` repository switched to **Trusted Publishing via GitHub Actions OIDC** in v1.2.4+. There is **no NPM_TOKEN secret** any more — the `NPM_PUBLISH_FIX.md` `npm whoami`-based workaround is no longer needed for releases.
+## One-time npm configuration
 
-This document is the one-shot setup checklist for the **package's npm settings page** (online, in a browser). Once the Trusted Publisher is added, every push of a `v*` tag triggers an unattended `npm publish` from CI without 2FA prompts.
+Open the [package settings](https://www.npmjs.com/package/@maxisoft/instantcms-mcp/access) as a package owner. In **Trusted Publisher**, select **GitHub Actions**:
 
----
+| Field | Value |
+| --- | --- |
+| Organization or user | `instantcms-dev` |
+| Repository | `instantcms-mcp` |
+| Workflow filename | `release.yml` |
+| Environment name | Leave blank |
+| Allowed actions | `npm publish` |
 
-## Why this exists
+Use only the workflow filename, **not** `.github/workflows/release.yml`. This is a package-level setting, not an account-wide publisher setting. npm does not validate these values when saving them; mistakes become visible during publication.
 
-The previous `NPM_TOKEN` repository secret was created in March 2026 for the original `instantcms-mcp@1.0.0` package and has only `read` / `update-existing` scopes. It cannot create a new scoped package, and the maintainer has 2FA enabled so `npm publish` from a local shell always prompts for OTP.
+The repository cannot configure or verify this private npm setting. A package owner must check it on npmjs.com. See the [official trusted publishing documentation](https://docs.npmjs.com/trusted-publishers/).
 
-**Trusted Publishing** solves both:
+## Workflow requirements
 
-- No long-lived secret in repository settings.
-- npm registry verifies the OIDC token issued by GitHub Actions (signed by `token.actions.githubusercontent.com`).
-- 2FA on the maintainer's npm account is **not consulted** because the publish comes from a CI identity, not a user identity.
+- GitHub-hosted runner with `id-token: write` on the publishing job.
+- Node.js 24 and an explicitly installed npm 11.18.0. npm's OIDC minimum is npm 11.5.1 with Node.js 22.14.0.
+- npm performs the OIDC exchange itself. Do not obtain a raw GitHub JWT with `core.getIDToken()` and write it into `_authToken`; that JWT is not an npm access token.
+- `package.json` declares the public Git repository URL matching `instantcms-dev/instantcms-mcp`, as required for [provenance](https://docs.npmjs.com/generating-provenance-statements/).
+- No `NODE_AUTH_TOKEN`, `NPM_TOKEN`, or manually generated authentication `.npmrc` is needed.
 
-Reference: https://docs.npmjs.com/trusted-publishers-with-npm-publish
+## Creating a release
 
-## One-time setup (browser)
+Merge the workflow fix before creating the release tag. The tagged commit must contain the corrected workflow, and `v<version>` must match both package manifests.
 
-1. Open https://www.npmjs.com/package/@maxisoft/instantcms-mcp — if the package is not yet published, the URL will 404; that's fine, do step 2 first and re-do step 3 once the first publish succeeds.
-2. Sign in to npmjs.com as the **package owner**: `maxisoft`.
-3. Go to **Account Settings → Trusted Publishers** (under **Publishing access**) → **Add a Trusted Publisher**.
+For a new version, from an up-to-date checkout:
 
-   Choose **GitHub Actions**.
-
-   - **Repository**: `instantcms-dev/instantcms-mcp`
-   - **Workflow filename**: `.github/workflows/release.yml`
-   - **Environment name**: leave blank (the workflow has no `environment:` clause).
-
-   Submit.
-
-4. Verify the entry now shows up in the package's Trusted Publishers list with the GitHub organisation, repo and workflow identifier.
-
-## Required workflow shape
-
-Already in place on `main` (and running CI green):
-
-- `permissions: { contents: read, id-token: write }` on the publish job.
-- `npm publish --access public --provenance`
-- `publishConfig: { access: "public", provenance: true }` in `package.json`.
-- No `NODE_AUTH_TOKEN` or `NPM_TOKEN` set in the environment of the publish step — npm must read the OIDC `ACTIONS_ID_TOKEN_*` from the runner.
-
-## First publish
-
-`@maxisoft/instantcms-mcp` does not yet exist on npm. To publish it for the first time:
-
-1. Re-tag the latest `v1.2.3`-like state (or bump to `1.2.4`):
-   ```bash
-   # From the repo root, with the trusted-publisher setup already done on npm:
-   git checkout main && git pull
-   # Bump version + push tag (e.g.):
-   npm version patch -m "chore(release): 1.2.4"
-   git push --follow-tags
-   ```
-   This pushes `v1.2.4` and the existing workflow does the publish — no interactive login, no NPM_TOKEN, no 2FA prompt.
-2. Watch the **Publish to npm (Trusted Publishing)** job on https://github.com/instantcms-dev/instantcms-mcp/actions.
-3. On success, the package appears at https://www.npmjs.com/package/@maxisoft/instantcms-mcp.
-
-If the first publish fails with `npm error 404 Not Found`, the Trusted Publisher entry has not propagated yet. Wait a minute and re-trigger by re-pushing the tag (`git tag -fa v1.2.4 -m "retry" && git push --force origin v1.2.4`).
-
-## Operational notes
-
-- **No more `NPM_TOKEN` secret.** A maintainer can rotate / delete it from repository secrets — nothing depends on it.
-- 2FA stays enabled on the npm account for ordinary local publishes. Trusted Publishing is **not** affected.
-- All releases continue to publish the GitHub Release ZIP for users who don't want to depend on npm.
-- If the workflow must be paused temporarily, set the job to `if: false` in `release.yml`, or comment out the `npm-publish-oidc` job.
-
-## Rollback
-
-If trusted publishing ever breaks (e.g., npm policy change), revert `.github/workflows/release.yml` to the older token-based shape:
-
-```yaml
-- name: Publish to npm
-  run: |
-    echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-    npm publish --access public
-  env:
-    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```bash
+npm version patch
+# Submit the version change through the repository's normal PR process.
+# After merge, push the corresponding tag pointing to the merged release commit.
 ```
 
-and remove `publishConfig.provenance` from `package.json`. The earlier `NPM_TOKEN` must then be a real publish-and-create-packages token (Granular Access Token, allow-publish-not-existing), and the first publish will only succeed after a maintainer adds that token.
+Pushing a `v*` tag runs validation, builds the ZIP, creates the GitHub Release, and publishes to npm. Publishing a GitHub Release manually also triggers the workflow. Both paths check out the release tag, not the latest branch tip.
 
-## Why this is safer than `NPM_TOKEN`
+Executions for the same tag are serialized. If that exact package version already exists, the npm publish step is skipped. Registry errors other than a missing version stop the workflow. Prereleases use dist-tag `next`; stable releases use `latest`.
 
-| Attack surface | `NPM_TOKEN` | Trusted Publishing |
-|----------------|------------|--------------------|
-| Secret expiry / leakage | Possible (long-lived token in GitHub) | Impossible (no persistent secret to leak) |
-| Insider takeover | Token allows publish under any scope | OIDC token is workflow-scoped, single-purpose, expiring |
-| Maintainer key | 2FA bypass token can outlive ownership | OIDC is per-job; user 2FA is not consulted |
-| Auditability | npm-side opaque | GitHub Actions OIDC claims are inspectable per release |
+## Recovering from the failed v1.2.4 release
 
-This is the modern npm-recommended flow and removes the entire class of bug we hit in 1.2.1–1.2.3.
+1. Merge this fix and verify the package's Trusted Publisher configuration above.
+2. Create a new release version/tag from a commit containing the fix. Do not force-move an existing release tag.
+3. Watch **Release → Publish to npm (Trusted Publishing)** in GitHub Actions.
+
+Re-running an old failed workflow uses its original workflow revision; it does not pick up changes merged into `main`. For a transient failure in the corrected workflow, retry the failed job. Already published versions cannot be overwritten.
+
+## Diagnosing failures
+
+- `E404`, `ENEEDAUTH`, or `E403`: inspect the npm error and verify the publisher's owner, repository, filename, allowed action, runner, npm version, and OIDC permission. A 404 is not proof of propagation delay or a missing package.
+- Provenance rejection: verify `repository.url` and that the source repository is public.
+- Version mismatch: update both manifests before tagging.
+- Published version: use a new version if package contents need to change.
+
+Local packing can verify package contents, but cannot test GitHub's OIDC identity or npm's private publisher settings. A successful GitHub Actions publish is the end-to-end verification.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 npm install @maxisoft/instantcms-mcp
 ```
 
-Это **первый релиз, опубликованный на центральном npm-реестре** через Trusted Publishing (GitHub Actions OpenID Connect). Пакет `instantcms-mcp` был `npm unpublish`ed в июне 2026, поэтому имя скопировано под scope `@maxisoft`. Для пользователей без доверия к npm также доступен GitHub Release ZIP:
+npm-пакет: `@maxisoft/instantcms-mcp`. Автоматическая публикация использует Trusted Publishing (GitHub Actions OIDC). Готовая сборка также доступна в GitHub Release ZIP:
 
 ```bash
 curl -L -O https://github.com/instantcms-dev/instantcms-mcp/releases/download/v1.2.4/instantcms-mcp-v1.2.4.zip
@@ -301,7 +301,9 @@ npm run build
 
 Изменения в `main` принимаются через Pull Request. GitHub требует успешные `Build`, Node.js 18/20/22/24 и `InstantCMS upstream compatibility`, один approving review, разрешение обсуждений и линейную историю. Force-push и удаление `main` запрещены классической branch protection и repository ruleset `Protect main`.
 
-Push тега `v*` запускает `.github/workflows/release.yml`: тесты, сборку, lint, создание ZIP и GitHub Release. Публикация в npm является отдельным шагом и требует рабочего repository secret `NPM_TOKEN` с правом создавать/обновлять пакет `instantcms-mcp`.
+Push тега `v*` или публикация GitHub Release запускает `.github/workflows/release.yml`: проверки, сборку, lint, создание ZIP и публикацию `@maxisoft/instantcms-mcp` в npm. Тег должен совпадать с версией в `package.json` и `package-lock.json`. Уже опубликованная версия пропускается; предварительные релизы публикуются с dist-tag `next`, стабильные — `latest`.
+
+Публикация использует Node.js 24, npm 11 и Trusted Publishing без `NPM_TOKEN`. В настройках npm-пакета необходимо привязать GitHub repository `instantcms-dev/instantcms-mcp` и workflow filename **`release.yml`**, без пути `.github/workflows/`. Подробности и восстановление после ошибки: [NPM_TRUSTED_PUBLISHING_SETUP.md](NPM_TRUSTED_PUBLISHING_SETUP.md).
 
 ## Лицензия
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MCP-сервер и набор переносимых AI-workflows для раз
 
 Сервер предоставляет структурированную базу API InstantCMS, безопасные генераторы, валидатор пакетов, диагностические инструменты и MCP resources. Runtime-данные синхронизированы с официальным репозиторием [`instantsoft/icms2`](https://github.com/instantsoft/icms2), последняя проверенная стабильная версия — **InstantCMS 2.18.2**.
 
-Текущий релиз: [`v1.2.4`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.4). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
+Текущий релиз: [`v1.2.5`](https://github.com/instantcms-dev/instantcms-mcp/releases/tag/v1.2.5). MCP работает автономно: доступ к GitHub нужен только сопровождающим проекта для обновления базы знаний.
 
 ### Установка
 
@@ -20,8 +20,8 @@ npm install @maxisoft/instantcms-mcp
 npm-пакет: `@maxisoft/instantcms-mcp`. Автоматическая публикация использует Trusted Publishing (GitHub Actions OIDC). Готовая сборка также доступна в GitHub Release ZIP:
 
 ```bash
-curl -L -O https://github.com/instantcms-dev/instantcms-mcp/releases/download/v1.2.4/instantcms-mcp-v1.2.4.zip
-unzip instantcms-mcp-v1.2.4.zip && cd instantcms-mcp-*/release
+curl -L -O https://github.com/instantcms-dev/instantcms-mcp/releases/download/v1.2.5/instantcms-mcp-v1.2.5.zip
+unzip instantcms-mcp-v1.2.5.zip && cd instantcms-mcp-*/release
 npm install --production
 node dist/index.js
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "instantcms-mcp",
-  "version": "1.2.0",
+  "name": "@maxisoft/instantcms-mcp",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "instantcms-mcp",
-      "version": "1.2.0",
+      "name": "@maxisoft/instantcms-mcp",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maxisoft/instantcms-mcp",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maxisoft/instantcms-mcp",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxisoft/instantcms-mcp",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "MCP server and reusable AI workflows for InstantCMS 2 development",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -91,5 +91,9 @@
     "tsx": "^4.23.12",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.68.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/instantcms-dev/instantcms-mcp.git"
   }
 }

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -30,7 +30,7 @@ describe('MCP integration', () => {
       expect(listed.tools.some(tool => tool.name === 'scaffold_template_php_quality')).toBe(true);
       expect(listed.tools).toHaveLength(100);
       const result = await client.callTool({ name: 'get_server_capabilities', arguments: {} });
-      expect(result.structuredContent).toMatchObject({ server_version: '1.2.4' });
+      expect(result.structuredContent).toMatchObject({ server_version: '1.2.5' });
     } finally {
       await client.close();
       await server.close();

--- a/src/registry/meta-tools.ts
+++ b/src/registry/meta-tools.ts
@@ -98,7 +98,7 @@ export function registerMetaTools(server: McpServer): void {
     'Версии, профили и объём базы знаний MCP-сервера',
     {},
     () => ({
-      server_version: '1.2.4',
+      server_version: '1.2.5',
       tools_count: 100,
       instantcms_profiles: instantCmsVersionProfiles,
       knowledge: {
@@ -195,7 +195,7 @@ export function registerMetaTools(server: McpServer): void {
     {},
     () => ({
       status: 'ready',
-      server_version: '1.2.4',
+      server_version: '1.2.5',
       tested_instantcms: '2.18.2',
       checks: ['npm run check', 'npm run test:integration', 'npm run build', 'npm audit'],
     })

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { registerTemplateDevelopmentTools } from './registry/template-developmen
 export function createServer(): McpServer {
   const server = new McpServer({
     name: 'instantcms-mcp',
-    version: '1.2.0',
+    version: '1.2.5',
     description: 'MCP сервер для разработки дополнений и шаблонов InstantCMS 2',
   });
 


### PR DESCRIPTION
## Problem

Publishing 1.2.4 failed with E404. The workflow passed a raw GitHub OIDC JWT as an npm access token and used Node 20 without an OIDC-capable npm CLI. Package repository metadata was missing, and the lockfile still identified the old unscoped package.

## Changes

Use Node 24 and npm 11.18.0 with native Trusted Publishing and the existing id-token permission. Add provenance repository metadata, synchronize manifests, and prepare version 1.2.5 without moving the existing v1.2.4 tag. Update the advertised MCP version and setup documentation.

Support both tag pushes and published GitHub Releases, validate tag/version agreement, serialize releases for the same tag, and skip versions already published to npm. Prereleases use the next dist-tag.

## Validation

- npm run check: 451 passed, 17 skipped.
- Build and lint passed for the workflow fix.
- npm pack dry run verified package contents.
- Workflow YAML and release validation checked, including registry HTTP 200/404/403/500 handling.

The npm package owner has confirmed Trusted Publisher setup. End-to-end OIDC verification requires the release workflow run after merge.
